### PR TITLE
FIX: Fix body length changed

### DIFF
--- a/proxyserver/src/main/java/com/lyft/data/proxyserver/wrapper/MultiReadHttpServletRequest.java
+++ b/proxyserver/src/main/java/com/lyft/data/proxyserver/wrapper/MultiReadHttpServletRequest.java
@@ -28,8 +28,9 @@ public class MultiReadHttpServletRequest extends HttpServletRequestWrapper {
     byte[] buffer = new byte[1024];
     while (true) {
       int bytesRead = in.read(buffer);
-      if (bytesRead == -1)
+      if (bytesRead == -1) {
         break;
+      }
       out.write(buffer, 0, bytesRead);
     }
   }


### PR DESCRIPTION
In current implementation, when downstream posts a content with "\r\n", the body length is changed.  
Which makes request proxied to upstream has "Content-Length" > body length  
So upstream server will wait forever (until timeout) for the request.

I have tested this pull request.

