### PR TITLE
FIX: Chinese string doesn't display correctly

### DIFF
--- a/gateway/src/main/resources/template/gateway-view.ftl
+++ b/gateway/src/main/resources/template/gateway-view.ftl
@@ -2,6 +2,7 @@
 <#setting datetime_format = "MM/dd/yyyy hh:mm:ss a '('zzz')'">
 <html>
 <head>
+    <meta charset="UTF-8"/>
     <style>
         .pull-left {
             float: left !important


### PR DESCRIPTION
In current implementation, Chinese string in web ui doesn't display correctly.  
I have tested the fix in Chrome.
