### PR TITLE
Allowing /v1/info to be routed by gateway

### DIFF
--- a/gateway/src/main/java/com/lyft/data/gateway/handler/QueryIdCachingProxyHandler.java
+++ b/gateway/src/main/java/com/lyft/data/gateway/handler/QueryIdCachingProxyHandler.java
@@ -38,6 +38,7 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
   public static final String PROXY_TARGET_HEADER = "proxytarget";
   public static final String V1_STATEMENT_PATH = "/v1/statement";
   public static final String V1_QUERY_PATH = "/v1/query";
+  public static final String V1_INFO_PATH = "/v1/info";
   public static final String QUERY_HTML_PATH = "/ui/query.html";
   public static final String SCHEDULED_QUERY_HEADER = "X-Presto-Scheduled-Query";
   public static final String USER_HEADER = "X-Presto-User";
@@ -113,7 +114,8 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     // Only load balance presto query APIs.
     if (request.getRequestURI().startsWith(V1_STATEMENT_PATH)
         || request.getRequestURI().startsWith(V1_QUERY_PATH)
-            || request.getRequestURI().startsWith(QUERY_HTML_PATH)) {
+        || request.getRequestURI().startsWith(QUERY_HTML_PATH)
+        || request.getRequestURI().startsWith(V1_INFO_PATH)) {
       String queryId = extractQueryIdIfPresent(request);
 
       // Find query id and get url from cache


### PR DESCRIPTION
DataGrip requires db version to validate connection to presto. Whitelisting `/v1/info` so that Datagrip can connect via presto-gateway.