### PR TITLE
Improve query id extraction for /v1/statement/.. endpoints

### DIFF
--- a/gateway/src/main/java/com/lyft/data/gateway/handler/QueryIdCachingProxyHandler.java
+++ b/gateway/src/main/java/com/lyft/data/gateway/handler/QueryIdCachingProxyHandler.java
@@ -189,14 +189,15 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     if (path.startsWith(V1_STATEMENT_PATH) || path.startsWith(V1_QUERY_PATH)) {
       String[] tokens = path.split("/");
       if (tokens.length >= 4) {
-          // for prestosql/presto api support link  https://github.com/prestosql/presto/blob/master/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java
-          if(path.indexOf("queued")>-1||path.indexOf("scheduled")>-1||path.indexOf("executing")>-1||path.indexOf("partialCancel")>-1){
-            queryId = tokens[4];
-          }
-          else {
-            queryId = tokens[3];
-          }
-       }
+        if (path.contains("queued")
+                || path.contains("scheduled")
+                || path.contains("executing")
+                || path.contains("partialCancel")) {
+          queryId = tokens[4];
+        } else {
+          queryId = tokens[3];
+        }
+      }
     } else if (path.startsWith(PRESTO_UI_PATH)) {
       queryId = queryParams;
     }

--- a/gateway/src/main/java/com/lyft/data/gateway/handler/QueryIdCachingProxyHandler.java
+++ b/gateway/src/main/java/com/lyft/data/gateway/handler/QueryIdCachingProxyHandler.java
@@ -189,8 +189,14 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     if (path.startsWith(V1_STATEMENT_PATH) || path.startsWith(V1_QUERY_PATH)) {
       String[] tokens = path.split("/");
       if (tokens.length >= 4) {
-        queryId = tokens[3];
-      }
+          // for prestosql/presto api support link  https://github.com/prestosql/presto/blob/master/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java
+          if(path.indexOf("queued")>-1||path.indexOf("scheduled")>-1||path.indexOf("executing")>-1||path.indexOf("partialCancel")>-1){
+            queryId = tokens[4];
+          }
+          else {
+            queryId = tokens[3];
+          }
+       }
     } else if (path.startsWith(PRESTO_UI_PATH)) {
       queryId = queryParams;
     }


### PR DESCRIPTION
do more check for statement status fix queryid get error for support prestosql/presto, api resouce   link https://github.com/prestosql/presto/blob/master/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java