### PR TITLE
Presto Queue Length Based Routing Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.editorconfig
 .idea
 **/target/*
 .DS_Store

--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.6.6</version>
+        <version>1.6.7</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/gateway-ha-config.yml
+++ b/gateway-ha/gateway-ha-config.yml
@@ -22,16 +22,13 @@ notifier:
   smtpPort: 587
   sender: presto-gw-monitor-noreply@lyft.com
   recipients:
-    - presto-dev@lyft.com
-    - presto-low-urgency-.zjiy85la@lyft.pagerduty.com
+    - prestodev@yourorg.com
 
 modules:
-  - com.lyft.data.gateway.ha.module.ClusterStateListenerModule
   - com.lyft.data.gateway.ha.module.HaGatewayProviderModule
 
 managedApps:
   - com.lyft.data.gateway.ha.GatewayManagedApp
-  - com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor
 
 # Logging settings.
 logging:

--- a/gateway-ha/gateway-ha-config.yml
+++ b/gateway-ha/gateway-ha-config.yml
@@ -22,13 +22,16 @@ notifier:
   smtpPort: 587
   sender: presto-gw-monitor-noreply@lyft.com
   recipients:
-    - prestodev@yourorg.com
+    - presto-dev@lyft.com
+    - presto-low-urgency-.zjiy85la@lyft.pagerduty.com
 
 modules:
+  - com.lyft.data.gateway.ha.module.ClusterStateListenerModule
   - com.lyft.data.gateway.ha.module.HaGatewayProviderModule
 
 managedApps:
   - com.lyft.data.gateway.ha.GatewayManagedApp
+  - com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor
 
 # Logging settings.
 logging:

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.6.6</version>
+        <version>1.6.7</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ClusterStats.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ClusterStats.java
@@ -6,12 +6,12 @@ import lombok.ToString;
 @Data
 @ToString
 public class ClusterStats {
-    private int runningQueryCount;
-    private int queuedQueryCount;
-    private int blockedQueryCount;
-    private int numWorkerNodes;
-    private boolean healthy;
-    private String clusterId;
-    private String proxyTo;
-    private String routingGroup;
+  private int runningQueryCount;
+  private int queuedQueryCount;
+  private int blockedQueryCount;
+  private int numWorkerNodes;
+  private boolean healthy;
+  private String clusterId;
+  private String proxyTo;
+  private String routingGroup;
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ClusterStats.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ClusterStats.java
@@ -1,0 +1,17 @@
+package com.lyft.data.gateway.ha.clustermonitor;
+
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@ToString
+public class ClusterStats {
+    private int runningQueryCount;
+    private int queuedQueryCount;
+    private int blockedQueryCount;
+    private int numWorkerNodes;
+    private boolean healthy;
+    private String clusterId;
+    private String proxyTo;
+    private String routingGroup;
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/HealthChecker.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/HealthChecker.java
@@ -26,7 +26,7 @@ public class HealthChecker implements PrestoClusterStatsObserver {
       }
     }
   }
-  
+
   private void notifyUnhealthyCluster(ClusterStats clusterStats) {
     notifier.sendNotification(String.format("%s - Cluster unhealthy",
         clusterStats.getClusterId()),

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/HealthChecker.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/HealthChecker.java
@@ -1,0 +1,46 @@
+package com.lyft.data.gateway.ha.clustermonitor;
+
+import com.google.inject.Inject;
+import com.lyft.data.gateway.ha.notifier.Notifier;
+
+import java.util.List;
+
+public class HealthChecker implements PrestoClusterStatsObserver {
+    private static final int MAX_THRESHOLD_QUEUED_QUERY_COUNT = 100;
+
+    @Inject
+    private Notifier notifier;
+
+    @Override
+    public void observe(List<ClusterStats> clustersStats) {
+        for (ClusterStats clusterStats : clustersStats) {
+            if (!clusterStats.isHealthy()) {
+                notifyUnhealthyCluster(clusterStats);
+            } else {
+                if (clusterStats.getQueuedQueryCount() > MAX_THRESHOLD_QUEUED_QUERY_COUNT) {
+                    notifyForTooManyQueuedQueries(clusterStats);
+                }
+                if (clusterStats.getNumWorkerNodes() < 1) {
+                    notifyForNoWorkers(clusterStats);
+                }
+            }
+        }
+    }
+
+    private void notifyUnhealthyCluster(ClusterStats clusterStats) {
+        notifier.sendNotification(String.format("%s - Cluster unhealthy",
+            clusterStats.getClusterId()),
+            clusterStats.toString());
+    }
+
+    private void notifyForTooManyQueuedQueries(ClusterStats clusterStats) {
+        notifier.sendNotification(String.format("%s - Too many queued queries",
+            clusterStats.getClusterId()), clusterStats.toString());
+    }
+
+    private void notifyForNoWorkers(ClusterStats clusterStats) {
+        notifier.sendNotification(String.format("%s - Number of workers",
+            clusterStats.getClusterId()), clusterStats.toString());
+    }
+
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/HealthChecker.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/HealthChecker.java
@@ -1,46 +1,47 @@
 package com.lyft.data.gateway.ha.clustermonitor;
 
-import com.google.inject.Inject;
 import com.lyft.data.gateway.ha.notifier.Notifier;
-
 import java.util.List;
 
 public class HealthChecker implements PrestoClusterStatsObserver {
-    private static final int MAX_THRESHOLD_QUEUED_QUERY_COUNT = 100;
+  private static final int MAX_THRESHOLD_QUEUED_QUERY_COUNT = 100;
+  private Notifier notifier;
 
-    @Inject
-    private Notifier notifier;
+  public HealthChecker(Notifier notifier) {
+    this.notifier = notifier;
+  }
 
-    @Override
-    public void observe(List<ClusterStats> clustersStats) {
-        for (ClusterStats clusterStats : clustersStats) {
-            if (!clusterStats.isHealthy()) {
-                notifyUnhealthyCluster(clusterStats);
-            } else {
-                if (clusterStats.getQueuedQueryCount() > MAX_THRESHOLD_QUEUED_QUERY_COUNT) {
-                    notifyForTooManyQueuedQueries(clusterStats);
-                }
-                if (clusterStats.getNumWorkerNodes() < 1) {
-                    notifyForNoWorkers(clusterStats);
-                }
-            }
+  @Override
+  public void observe(List<ClusterStats> clustersStats) {
+    for (ClusterStats clusterStats : clustersStats) {
+      if (!clusterStats.isHealthy()) {
+        notifyUnhealthyCluster(clusterStats);
+      } else {
+        if (clusterStats.getQueuedQueryCount() > MAX_THRESHOLD_QUEUED_QUERY_COUNT) {
+          notifyForTooManyQueuedQueries(clusterStats);
         }
+        if (clusterStats.getNumWorkerNodes() < 1) {
+          notifyForNoWorkers(clusterStats);
+        }
+      }
     }
+  }
+  
+  private void notifyUnhealthyCluster(ClusterStats clusterStats) {
+    notifier.sendNotification(String.format("%s - Cluster unhealthy",
+        clusterStats.getClusterId()),
+        clusterStats.toString());
+  }
 
-    private void notifyUnhealthyCluster(ClusterStats clusterStats) {
-        notifier.sendNotification(String.format("%s - Cluster unhealthy",
-            clusterStats.getClusterId()),
-            clusterStats.toString());
-    }
+  private void notifyForTooManyQueuedQueries(ClusterStats clusterStats) {
+    notifier.sendNotification(String.format("%s - Too many queued queries",
+        clusterStats.getClusterId()), clusterStats.toString());
+  }
 
-    private void notifyForTooManyQueuedQueries(ClusterStats clusterStats) {
-        notifier.sendNotification(String.format("%s - Too many queued queries",
-            clusterStats.getClusterId()), clusterStats.toString());
-    }
+  private void notifyForNoWorkers(ClusterStats clusterStats) {
+    notifier.sendNotification(String.format("%s - Number of workers",
+        clusterStats.getClusterId()), clusterStats.toString());
+  }
 
-    private void notifyForNoWorkers(ClusterStats clusterStats) {
-        notifier.sendNotification(String.format("%s - Number of workers",
-            clusterStats.getClusterId()), clusterStats.toString());
-    }
 
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoClusterStatsObserver.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoClusterStatsObserver.java
@@ -1,0 +1,8 @@
+package com.lyft.data.gateway.ha.clustermonitor;
+
+import java.util.List;
+
+public interface PrestoClusterStatsObserver {
+
+    public void observe(List<ClusterStats> stats);
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoClusterStatsObserver.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoClusterStatsObserver.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 public interface PrestoClusterStatsObserver {
 
-    public void observe(List<ClusterStats> stats);
+  void observe(List<ClusterStats> stats);
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoQueueLengthChecker.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoQueueLengthChecker.java
@@ -1,0 +1,40 @@
+package com.lyft.data.gateway.ha.clustermonitor;
+
+import com.lyft.data.gateway.ha.router.PrestoQueueLengthRoutingTable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Updates the QueueLength Based Routing Manager {@link PrestoQueueLengthRoutingTable} with
+ * updated queue lengths of active clusters.
+ */
+public class PrestoQueueLengthChecker implements PrestoClusterStatsObserver {
+
+  PrestoQueueLengthRoutingTable routingManager;
+
+  public PrestoQueueLengthChecker(PrestoQueueLengthRoutingTable routingManager) {
+    this.routingManager = routingManager;
+  }
+
+  @Override
+  public void observe(List<ClusterStats> stats) {
+    Map<String, Map<String, Integer>> clusterQueueMap = new HashMap<String, Map<String, Integer>>();
+
+    for (ClusterStats stat : stats) {
+      if (!clusterQueueMap.containsKey(stat.getRoutingGroup())) {
+        clusterQueueMap.put(stat.getRoutingGroup(), new HashMap<String, Integer>() {
+              {
+                put(stat.getClusterId(), stat.getQueuedQueryCount());
+              }
+            }
+        );
+      } else {
+        clusterQueueMap.get(stat.getRoutingGroup()).put(stat.getClusterId(),
+            stat.getQueuedQueryCount());
+      }
+    }
+
+    routingManager.updateRoutingTable(clusterQueueMap);
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/ClusterStateListenerModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/ClusterStateListenerModule.java
@@ -1,0 +1,27 @@
+package com.lyft.data.gateway.ha.module;
+
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.lyft.data.baseapp.AppModule;
+import com.lyft.data.gateway.ha.clustermonitor.HealthChecker;
+import com.lyft.data.gateway.ha.clustermonitor.PrestoClusterStatsObserver;
+import com.lyft.data.gateway.ha.config.HaGatewayConfiguration;
+import io.dropwizard.setup.Environment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ClusterStateListenerModule extends AppModule<HaGatewayConfiguration, Environment> {
+
+    public ClusterStateListenerModule(HaGatewayConfiguration config, Environment env) {
+        super(config, env);
+    }
+
+    @Provides
+    @Singleton
+    public List<PrestoClusterStatsObserver> getClusterStatsObservers() {
+        List<PrestoClusterStatsObserver> observers = new ArrayList<>();
+        observers.add(new HealthChecker());
+        return observers;
+    }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/ClusterStateListenerModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/ClusterStateListenerModule.java
@@ -6,22 +6,31 @@ import com.lyft.data.baseapp.AppModule;
 import com.lyft.data.gateway.ha.clustermonitor.HealthChecker;
 import com.lyft.data.gateway.ha.clustermonitor.PrestoClusterStatsObserver;
 import com.lyft.data.gateway.ha.config.HaGatewayConfiguration;
+import com.lyft.data.gateway.ha.config.NotifierConfiguration;
+import com.lyft.data.gateway.ha.notifier.EmailNotifier;
 import io.dropwizard.setup.Environment;
-
 import java.util.ArrayList;
 import java.util.List;
 
 public class ClusterStateListenerModule extends AppModule<HaGatewayConfiguration, Environment> {
+  List<PrestoClusterStatsObserver> observers;
 
-    public ClusterStateListenerModule(HaGatewayConfiguration config, Environment env) {
-        super(config, env);
-    }
+  public ClusterStateListenerModule(HaGatewayConfiguration config, Environment env) {
+    super(config, env);
+  }
 
-    @Provides
-    @Singleton
-    public List<PrestoClusterStatsObserver> getClusterStatsObservers() {
-        List<PrestoClusterStatsObserver> observers = new ArrayList<>();
-        observers.add(new HealthChecker());
-        return observers;
-    }
+  /**
+   * Observers to cluster stats updates from
+   * {@link com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor}.
+   *
+   * @return
+   */
+  @Provides
+  @Singleton
+  public List<PrestoClusterStatsObserver> getClusterStatsObservers() {
+    observers = new ArrayList<>();
+    NotifierConfiguration notifierConfiguration = getConfiguration().getNotifier();
+    observers.add(new HealthChecker(new EmailNotifier(notifierConfiguration)));
+    return observers;
+  }
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
@@ -4,20 +4,26 @@ import com.codahale.metrics.Meter;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.lyft.data.baseapp.AppModule;
+import com.lyft.data.gateway.ha.clustermonitor.HealthChecker;
+import com.lyft.data.gateway.ha.clustermonitor.PrestoClusterStatsObserver;
+import com.lyft.data.gateway.ha.clustermonitor.PrestoQueueLengthChecker;
 import com.lyft.data.gateway.ha.config.HaGatewayConfiguration;
 import com.lyft.data.gateway.ha.config.RequestRouterConfiguration;
 import com.lyft.data.gateway.ha.handler.QueryIdCachingProxyHandler;
+import com.lyft.data.gateway.ha.notifier.EmailNotifier;
 import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
 import com.lyft.data.gateway.ha.router.GatewayBackendManager;
 import com.lyft.data.gateway.ha.router.HaGatewayManager;
 import com.lyft.data.gateway.ha.router.HaQueryHistoryManager;
-import com.lyft.data.gateway.ha.router.HaRoutingManager;
+import com.lyft.data.gateway.ha.router.PrestoQueueLengthRoutingTable;
 import com.lyft.data.gateway.ha.router.QueryHistoryManager;
 import com.lyft.data.gateway.ha.router.RoutingManager;
 import com.lyft.data.proxyserver.ProxyHandler;
 import com.lyft.data.proxyserver.ProxyServer;
 import com.lyft.data.proxyserver.ProxyServerConfiguration;
 import io.dropwizard.setup.Environment;
+import java.util.ArrayList;
+import java.util.List;
 
 public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, Environment> {
 
@@ -37,6 +43,11 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
         getQueryHistoryManager(), getRoutingManager(), getApplicationPort(), requestMeter);
   }
 
+  /**
+   * Provides a HA Gateway.
+   *
+   * @return
+   */
   @Provides
   @Singleton
   public ProxyServer provideGateway() {
@@ -80,6 +91,25 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
   @Provides
   @Singleton
   public RoutingManager getRoutingManager() {
-    return new HaRoutingManager(getGatewayBackendManager(), (HaQueryHistoryManager) getQueryHistoryManager() );
+    return new PrestoQueueLengthRoutingTable(getGatewayBackendManager(), getQueryHistoryManager());
   }
+
+  /**
+   * Injects observers of the
+   * {@link com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor} that can perform a custom
+   * action in reponse to the status updates.
+   *
+   * @return
+   */
+  @Provides
+  @Singleton
+  public List<PrestoClusterStatsObserver> getClusterStatsObservers() {
+    List<PrestoClusterStatsObserver> observers = new ArrayList<>();
+    observers.add(new HealthChecker(new EmailNotifier(getConfiguration().getNotifier())));
+    observers.add(new
+        PrestoQueueLengthChecker((PrestoQueueLengthRoutingTable) getRoutingManager()));
+    return observers;
+  }
+
+
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
@@ -21,18 +21,11 @@ import io.dropwizard.setup.Environment;
 
 public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, Environment> {
 
-  private final GatewayBackendManager gatewayBackendManager;
-  private final QueryHistoryManager queryHistoryManager;
-  private final RoutingManager routingManager;
   private final JdbcConnectionManager connectionManager;
 
   public HaGatewayProviderModule(HaGatewayConfiguration configuration, Environment environment) {
     super(configuration, environment);
     connectionManager = new JdbcConnectionManager(configuration.getDataStore());
-    gatewayBackendManager = new HaGatewayManager(connectionManager);
-    queryHistoryManager = new HaQueryHistoryManager(connectionManager);
-    routingManager =
-        new HaRoutingManager(gatewayBackendManager, (HaQueryHistoryManager) queryHistoryManager);
   }
 
   protected ProxyHandler getProxyHandler() {
@@ -69,24 +62,24 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
   @Provides
   @Singleton
   public GatewayBackendManager getGatewayBackendManager() {
-    return this.gatewayBackendManager;
+    return new HaGatewayManager(getConnectionManager());
   }
 
   @Provides
   @Singleton
   public QueryHistoryManager getQueryHistoryManager() {
-    return this.queryHistoryManager;
-  }
-
-  @Provides
-  @Singleton
-  public RoutingManager getRoutingManager() {
-    return this.routingManager;
+    return new HaQueryHistoryManager(getConnectionManager());
   }
 
   @Provides
   @Singleton
   public JdbcConnectionManager getConnectionManager() {
     return this.connectionManager;
+  }
+
+  @Provides
+  @Singleton
+  public RoutingManager getRoutingManager() {
+    return new HaRoutingManager(getGatewayBackendManager(), (HaQueryHistoryManager) getQueryHistoryManager() );
   }
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
@@ -89,4 +89,5 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
   public JdbcConnectionManager getConnectionManager() {
     return this.connectionManager;
   }
+
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaQueryHistoryManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaQueryHistoryManager.java
@@ -34,6 +34,7 @@ public class HaQueryHistoryManager implements QueryHistoryManager {
     }
   }
 
+  @Override
   public String getBackendForQueryId(String queryId) {
     String backend = null;
     try {

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaRoutingManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaRoutingManager.java
@@ -5,20 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class HaRoutingManager extends RoutingManager {
-  HaQueryHistoryManager queryHistoryManager;
+  QueryHistoryManager queryHistoryManager;
 
   public HaRoutingManager(
-      GatewayBackendManager gatewayBackendManager, HaQueryHistoryManager queryHistoryManager) {
+      GatewayBackendManager gatewayBackendManager, QueryHistoryManager queryHistoryManager) {
     super(gatewayBackendManager);
     this.queryHistoryManager = queryHistoryManager;
-  }
-
-  protected String findBackendForUnknownQueryId(String queryId) {
-    String backend;
-    backend = queryHistoryManager.getBackendForQueryId(queryId);
-    if (Strings.isNullOrEmpty(backend)) {
-      backend = super.findBackendForUnknownQueryId(queryId);
-    }
-    return backend;
   }
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
@@ -75,10 +75,10 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
 
     if (maxQueueLn == 0) {
       calculatedWtMaxQueue = MAX_WT;
-    } else if (lastButOneQueueLn == 0) {
+    } else if (lastButOneQueueLn == 0 || (lastButOneQueueLn == maxQueueLn)) {
       calculatedWtMaxQueue = MIN_WT;
     } else {
-      int lastButOneQueueWt = (MAX_WT - (lastButOneQueueLn * MAX_WT / maxQueueLn));
+      int lastButOneQueueWt = (int) Math.ceil((MAX_WT - (lastButOneQueueLn * MAX_WT / (double) maxQueueLn)));
       double fractionOfLastWt = (smallestQueueLn / (float) maxQueueLn);
       calculatedWtMaxQueue = (int) Math.ceil(fractionOfLastWt * lastButOneQueueWt);
 
@@ -153,7 +153,7 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
         for (int i = 0; i < numBuckets - 1; i++) {
           // If all clusters have same queue length, assign same wt
           weight = (maxQueueLn == (Integer) queueLengths[i]) ? calculatedWtMaxQueue :
-              MAX_WT - (((Integer) queueLengths[i] * MAX_WT) / maxQueueLn);
+              (int) Math.ceil(MAX_WT - (((Integer) queueLengths[i] * MAX_WT) / (double) maxQueueLn));
           sum += weight;
           weightsMap.put(sum, (String) clusterNames[i]);
         }
@@ -312,6 +312,12 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
       int backendId = Math.abs(RANDOM.nextInt()) % backends.size();
       return backends.get(backendId).getProxyTo();
     }
+  }
+
+
+  public static  void main (String[] args)
+  {
+    System.out.println((int)Math.ceil( 113/(float)112));
   }
 
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
@@ -82,7 +82,8 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
       double fractionOfLastWt = (smallestQueueLn / (float) maxQueueLn);
       calculatedWtMaxQueue = (int) Math.ceil(fractionOfLastWt * lastButOneQueueWt);
 
-      if (lastButOneQueueLn < equalDistribution || (lastButOneQueueLn > equalDistribution && smallestQueueLn <= equalDistribution)) {
+      if (lastButOneQueueLn < equalDistribution
+          || (lastButOneQueueLn > equalDistribution && smallestQueueLn <= equalDistribution)) {
         calculatedWtMaxQueue = (smallestQueueLn == 0) ? MIN_WT :
             (int) Math.ceil(fractionOfLastWt * fractionOfLastWt * lastButOneQueueWt);
       }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
@@ -1,313 +1,336 @@
 package com.lyft.data.gateway.ha.router;
 
-import com.lyft.data.gateway.ha.clustermonitor.ClusterStats;
-import com.lyft.data.gateway.ha.clustermonitor.PrestoClusterStatsObserver;
 import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
-
-import java.util.*;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * A Routing Manager that provides load distribution on to registered active backends based on its queue length.
- * This manager listens to updates on cluster queue length as recorded by the
+ * A Routing Manager that provides load distribution on to registered active backends based on
+ * its queue length. This manager listens to updates on cluster queue length as recorded by the
  * {@link com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor}
- * Ideally where ever a modification is made to the the list of backends(adding, removing) this routing
- * manager should get notified & updated.
+ * Ideally where ever a modification is made to the the list of backends(adding, removing) this
+ * routing manager should get notified & updated.
  * Currently updates are made only on heart beats from
  * {@link com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor} & during routing requests.
  */
 @Slf4j
-public class PrestoQueueLengthRoutingTable extends HaRoutingManager implements PrestoClusterStatsObserver {
-    private static final Random RANDOM = new Random();
-    private ConcurrentHashMap<String, Integer> routingGroupWeightSum;
-    private ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>> clusterQueueLengthMap;
-    private Map<String, TreeMap<Integer, String>> weightedDistributionRouting;
-    private final Object lockObject = new Object();
-    private final int MIN_WT = 1;
-    private final int MAX_WT = 100;
+public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
+  private static final Random RANDOM = new Random();
+  private final Object lockObject = new Object();
+  private static final int MIN_WT = 1;
+  private static final int MAX_WT = 100;
+  private ConcurrentHashMap<String, Integer> routingGroupWeightSum;
+  private ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>> clusterQueueLengthMap;
+  private Map<String, TreeMap<Integer, String>> weightedDistributionRouting;
+
+  /**
+   * A Routing Manager that distributes queries according to assigned weights based on
+   * Presto cluster queue length.
+   *
+   * @param gatewayBackendManager
+   * @param queryHistoryManager
+   */
+  public PrestoQueueLengthRoutingTable(GatewayBackendManager gatewayBackendManager,
+                                       QueryHistoryManager queryHistoryManager) {
+    super(gatewayBackendManager, queryHistoryManager);
+    routingGroupWeightSum = new ConcurrentHashMap<String, Integer>();
+    clusterQueueLengthMap = new ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>>();
+    weightedDistributionRouting = new HashMap<String, TreeMap<Integer, String>>();
+  }
 
 
-    public PrestoQueueLengthRoutingTable(GatewayBackendManager gatewayBackendManager, QueryHistoryManager queryHistoryManager) {
-        super(gatewayBackendManager, queryHistoryManager);
-        routingGroupWeightSum = new ConcurrentHashMap<String, Integer>();
-        clusterQueueLengthMap = new ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>>();
-        weightedDistributionRouting = new HashMap<String, TreeMap<Integer, String>>();
-    }
+  /**
+   * Uses the queue length of a cluster to assign weights to all active clusters in a routing group.
+   * The weights assigned ensure a fair distribution of routing for queries such that clusters with
+   * the least queue length get assigned more queries.
+   *
+   * @param queueLengthMap
+   */
+  private void computeWeightsBasedOnQueueLength(ConcurrentHashMap<String,
+      ConcurrentHashMap<String, Integer>> queueLengthMap) {
+    synchronized (lockObject) {
+      int sum = 0;
+      int queueSum = 0;
+      int weight;
+      int numBuckets = 1;
+      int equalDistribution = 0;
+      int smallestQueueLn = 0;
+      int lastButOneQueueLn = 0;
+      int maxQueueLn = 0;
+      int calculatedWtMaxQueue = 0;
 
-    /**
-     * Uses the queue length of a cluster to assign weights to all active clusters in a routing group.
-     * The weights assigned ensure a fair distribution of routing for queries such that clusters with the least
-     * queue length get assigned more queries.
-     *
-     * @param queueLengthMap
-     */
-    private void computeWeightsBasedOnQueueLength(ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>> queueLengthMap) {
-        synchronized (lockObject) {
-            int sum, queue_sum = 0, weight, num_buckets = 1, equal_distribution = 0, smallest_queue_ln = 0, last_but_one_queue_ln = 0,
-                    max_queue_ln = 0, calculated_wt_max_queue = 0;
+      weightedDistributionRouting.clear();
+      routingGroupWeightSum.clear();
 
-            weightedDistributionRouting.clear();
-            routingGroupWeightSum.clear();
+      log.debug("Computing Weights for Queue Map " + queueLengthMap.toString());
 
-            log.debug("Computing Weights for Queue Map " + queueLengthMap.toString());
+      for (String routingGroup : queueLengthMap.keySet()) {
+        sum = 0;
+        TreeMap<Integer, String> weightsMap = new TreeMap<>();
 
-            for (String routingGroup : queueLengthMap.keySet()) {
-                sum = 0;
-                TreeMap<Integer, String> weightsMap = new TreeMap<>();
-
-                if (queueLengthMap.get(routingGroup).size() == 0) {
-                    log.warn("No active clusters in routingGroup : " + routingGroup + ". Continue to process rest of routing table ");
-                    continue;
-                } else if (queueLengthMap.get(routingGroup).size() == 1) {
-                    log.debug("Routing Group: " + routingGroup + " has only 1 active backend. ");
-                    weightedDistributionRouting.put(routingGroup, new TreeMap<Integer, String>() {{
-                        put(MAX_WT, queueLengthMap.get(routingGroup).keys().nextElement());
-                    }});
-                    routingGroupWeightSum.put(routingGroup, MAX_WT);
-                    continue;
+        if (queueLengthMap.get(routingGroup).size() == 0) {
+          log.warn("No active clusters in routingGroup : " + routingGroup + ". Continue to "
+              + "process rest of routing table ");
+          continue;
+        } else if (queueLengthMap.get(routingGroup).size() == 1) {
+          log.debug("Routing Group: " + routingGroup + " has only 1 active backend. ");
+          weightedDistributionRouting.put(routingGroup, new TreeMap<Integer, String>() {
+                {
+                  put(MAX_WT, queueLengthMap.get(routingGroup).keys().nextElement());
                 }
-
-                Map<String, Integer> sortedByQueueLength = queueLengthMap.get(routingGroup).entrySet().stream().sorted(Comparator.comparing(Map.Entry::getValue))
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
-                                (e1, e2) -> e1, LinkedHashMap::new));
-
-                num_buckets = sortedByQueueLength.size();
-                queue_sum = sortedByQueueLength.values().stream().mapToInt(Integer::intValue).sum();
-                equal_distribution = queue_sum / num_buckets;
-
-                Object[] queueLengths = sortedByQueueLength.values().toArray();
-                Object[] clusterNames = sortedByQueueLength.keySet().toArray();
-
-                smallest_queue_ln = (Integer)queueLengths[0];
-                max_queue_ln = (Integer)queueLengths[queueLengths.length - 1];
-                last_but_one_queue_ln = smallest_queue_ln;
-                if (queueLengths.length > 2) {
-                    last_but_one_queue_ln = (Integer)queueLengths[queueLengths.length - 2];
-                }
-
-                /**
-                 *  All wts are assigned as a fraction of max_queue_ln. Cluster with max_queue_ln should be given least
-                 *  weightage. What this value should be depends on the queueing on the rest of the clusters. since the list
-                 *  is sorted, the smallest_queue_ln & last_but_one_queue_ln give us the range.
-                 *
-                 *  In an ideal situation all clusters should have equals distribution of queries, hence that is used as
-                 *  a threshold to check is a cluster queue is over provisioned or not.
-                 */
-
-                if (max_queue_ln == 0) {
-                    calculated_wt_max_queue = MAX_WT;
-                } else if (last_but_one_queue_ln == 0) {
-                    calculated_wt_max_queue = MIN_WT;
-                } else {
-                    float fraction_of_last_but_one_wt = (last_but_one_queue_ln / (float) max_queue_ln) * (MAX_WT - (last_but_one_queue_ln * MAX_WT / max_queue_ln));
-
-                    if (smallest_queue_ln == 0) {
-                        if (last_but_one_queue_ln < equal_distribution) {
-                            calculated_wt_max_queue = MIN_WT;
-                        } else {
-                            calculated_wt_max_queue = (int)fraction_of_last_but_one_wt;
-                        }
-                    } else if (smallest_queue_ln < equal_distribution) {
-                        if (last_but_one_queue_ln <= equal_distribution) {
-                            calculated_wt_max_queue = (fraction_of_last_but_one_wt / 2 > 0 ) ? (int)fraction_of_last_but_one_wt / 2 : MIN_WT;
-                        } else {
-                            calculated_wt_max_queue = (fraction_of_last_but_one_wt/1.5 > 0) ? (int)(fraction_of_last_but_one_wt/1.5): MIN_WT;
-                        }
-                    } else {
-                        calculated_wt_max_queue = (int)fraction_of_last_but_one_wt;
-                    }
-                }
-
-                for (int i = 0; i < num_buckets - 1; i++) {
-                    // If all clusters have same queue length, assign same wt
-                    weight = (max_queue_ln == (Integer)queueLengths[i]) ? calculated_wt_max_queue : MAX_WT - (((Integer)queueLengths[i] * MAX_WT) / max_queue_ln);
-                    sum += weight;
-                    weightsMap.put(sum, (String) clusterNames[i]);
-                }
-
-                sum += calculated_wt_max_queue;
-                weightsMap.put(sum, (String)clusterNames[num_buckets - 1]);
-
-                weightedDistributionRouting.put(routingGroup, weightsMap);
-                routingGroupWeightSum.put(routingGroup, sum);
-            }
-
-            if (log.isDebugEnabled()) {
-                for (String rg : weightedDistributionRouting.keySet()) {
-                    log.debug(String.format("Routing Table for : {%s} is {%s}", rg, weightedDistributionRouting.get(rg).toString()));
-                }
-            }
-        }
-    }
-
-    /**
-     * Update the Routing Table only if a previously known backend has been deactivated.
-     * Newly added backends are handled through {@link PrestoQueueLengthRoutingTable#updateRoutingTable(Map)}
-     * updateRoutingTable}
-     *
-     * @param routingGroup
-     * @param backends
-     */
-    protected void updateRoutingTable(String routingGroup, Set<String> backends) {
-
-        synchronized (lockObject) {
-            if (clusterQueueLengthMap.containsKey(routingGroup)) {
-                Collection<String> knownBackends = new HashSet<String>();
-                knownBackends.addAll(clusterQueueLengthMap.get(routingGroup).keySet());
-
-                if (backends.containsAll(knownBackends)) {
-                    return;
-                } else {
-                    if (knownBackends.removeAll(backends)) {
-                        for (String inactiveBackend : knownBackends) {
-                            clusterQueueLengthMap.get(routingGroup).remove(inactiveBackend);
-                        }
-                    }
-                }
-            }
-
-            computeWeightsBasedOnQueueLength(clusterQueueLengthMap);
-        }
-    }
-
-    /**
-     * Update routing Table with new Queue Lengths
-     *
-     * @param updatedQueueLengthMap
-     */
-    protected void updateRoutingTable(Map<String, Map<String, Integer>> updatedQueueLengthMap) {
-        synchronized (lockObject) {
-            clusterQueueLengthMap.clear();
-
-            for (String grp : updatedQueueLengthMap.keySet()) {
-                ConcurrentHashMap<String, Integer> queueMap = new ConcurrentHashMap<>();
-                queueMap.putAll(updatedQueueLengthMap.get(grp));
-                clusterQueueLengthMap.put(grp, queueMap);
-            }
-
-            computeWeightsBasedOnQueueLength(clusterQueueLengthMap);
+              }
+          );
+          routingGroupWeightSum.put(routingGroup, MAX_WT);
+          continue;
         }
 
-    }
+        Map<String, Integer> sortedByQueueLength = queueLengthMap.get(routingGroup).entrySet()
+            .stream().sorted(Comparator.comparing(Map.Entry::getValue))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                (e1, e2) -> e1, LinkedHashMap::new));
 
-    /**
-     * @param routingGroup
-     * @return
-     */
-    public Map<String, Integer> getInternalWeightedRoutingTable(String routingGroup) {
-        if (!weightedDistributionRouting.containsKey(routingGroup))
-            return null;
-        Map<String, Integer> routingTable = new HashMap<>();
+        numBuckets = sortedByQueueLength.size();
+        queueSum = sortedByQueueLength.values().stream().mapToInt(Integer::intValue).sum();
+        equalDistribution = queueSum / numBuckets;
 
-        for (Integer wt : weightedDistributionRouting.get(routingGroup).keySet()) {
-            routingTable.put(weightedDistributionRouting.get(routingGroup).get(wt), wt);
+        Object[] queueLengths = sortedByQueueLength.values().toArray();
+        Object[] clusterNames = sortedByQueueLength.keySet().toArray();
+
+        smallestQueueLn = (Integer) queueLengths[0];
+        maxQueueLn = (Integer) queueLengths[queueLengths.length - 1];
+        lastButOneQueueLn = smallestQueueLn;
+        if (queueLengths.length > 2) {
+          lastButOneQueueLn = (Integer) queueLengths[queueLengths.length - 2];
         }
-        return routingTable;
-    }
 
-    /**
-     * @param routingGroup
-     * @return
-     */
-    public Map<String, Integer> getInternalClusterQueueLength(String routingGroup) {
-        if (!clusterQueueLengthMap.containsKey(routingGroup))
-            return null;
+        /**
+         *  All wts are assigned as a fraction of maxQueueLn. Cluster with maxQueueLn should be
+         *  given least weightage. What this value should be depends on the queueing on the rest of
+         *  the clusters. since the list is sorted, the smallestQueueLn & lastButOneQueueLn give us
+         *  the range. In an ideal situation all clusters should have equals distribution of
+         *  queries, hence that is used as a threshold to check is a cluster queue is over
+         *  provisioned or not.
+         */
 
-        return clusterQueueLengthMap.get(routingGroup);
-    }
+        if (maxQueueLn == 0) {
+          calculatedWtMaxQueue = MAX_WT;
+        } else if (lastButOneQueueLn == 0) {
+          calculatedWtMaxQueue = MIN_WT;
+        } else {
+          float fractionOfLastWt =
+              (lastButOneQueueLn / (float) maxQueueLn)
+                  * (MAX_WT - (lastButOneQueueLn * MAX_WT / maxQueueLn));
 
-    /**
-     * Looks up the closest weight to random number generated for a given routing group.
-     *
-     * @param routingGroup
-     * @return
-     */
-    public String getEligibleBackEnd(String routingGroup) {
-        if (routingGroupWeightSum.containsKey(routingGroup) && weightedDistributionRouting.containsKey(routingGroup)) {
-            int rnd = RANDOM.nextInt(routingGroupWeightSum.get(routingGroup));
-            return weightedDistributionRouting.get(routingGroup).higherEntry(rnd).getValue();
-        } else
-            return null;
-    }
-
-
-    @Override
-    public void observe(List<ClusterStats> stats) {
-        Map<String, Map<String, Integer>> clusterQueueMap = new HashMap<String, Map<String, Integer>>();
-
-        for (ClusterStats stat : stats) {
-            if (!clusterQueueMap.containsKey(stat.getRoutingGroup())) {
-                clusterQueueMap.put(stat.getRoutingGroup(), new HashMap<String, Integer>() {{
-                    put(stat.getClusterId(), stat.getQueuedQueryCount());
-                }});
+          if (smallestQueueLn == 0) {
+            if (lastButOneQueueLn < equalDistribution) {
+              calculatedWtMaxQueue = MIN_WT;
             } else {
-                clusterQueueMap.get(stat.getRoutingGroup()).put(stat.getClusterId(), stat.getQueuedQueryCount());
+              calculatedWtMaxQueue = (int) fractionOfLastWt;
             }
+          } else if (smallestQueueLn < equalDistribution) {
+            if (lastButOneQueueLn <= equalDistribution) {
+              calculatedWtMaxQueue = (fractionOfLastWt / 2 > 0)
+                  ? (int) fractionOfLastWt / 2 : MIN_WT;
+            } else {
+              calculatedWtMaxQueue = (fractionOfLastWt / 1.5 > 0)
+                  ? (int) (fractionOfLastWt / 1.5) : MIN_WT;
+            }
+          } else {
+            calculatedWtMaxQueue = (int) fractionOfLastWt;
+          }
         }
 
-        updateRoutingTable(clusterQueueMap);
+        for (int i = 0; i < numBuckets - 1; i++) {
+          // If all clusters have same queue length, assign same wt
+          weight = (maxQueueLn == (Integer) queueLengths[i]) ? calculatedWtMaxQueue :
+              MAX_WT - (((Integer) queueLengths[i] * MAX_WT) / maxQueueLn);
+          sum += weight;
+          weightsMap.put(sum, (String) clusterNames[i]);
+        }
+
+        sum += calculatedWtMaxQueue;
+        weightsMap.put(sum, (String) clusterNames[numBuckets - 1]);
+
+        weightedDistributionRouting.put(routingGroup, weightsMap);
+        routingGroupWeightSum.put(routingGroup, sum);
+      }
+
+      if (log.isDebugEnabled()) {
+        for (String rg : weightedDistributionRouting.keySet()) {
+          log.debug(String.format("Routing Table for : {%s} is {%s}", rg,
+              weightedDistributionRouting.get(rg).toString()));
+        }
+      }
     }
+  }
 
-    /**
-     * Performs routing to a given cluster group. This falls back to an adhoc backend, if no scheduled
-     * backend is found.
-     *
-     * @return
-     */
-    @Override
-    public String provideBackendForRoutingGroup(String routingGroup) {
-        List<ProxyBackendConfiguration> backends =
-                getGatewayBackendManager().getActiveBackends(routingGroup);
+  /**
+   * Update the Routing Table only if a previously known backend has been deactivated.
+   * Newly added backends are handled through
+   * {@link PrestoQueueLengthRoutingTable#updateRoutingTable(Map)}
+   * updateRoutingTable}
+   *
+   * @param routingGroup
+   * @param backends
+   */
+  public void updateRoutingTable(String routingGroup, Set<String> backends) {
 
-        if (backends.isEmpty()) {
-            return provideAdhocBackend();
-        }
-        Map<String, String> proxyMap = new HashMap<>();
-        for (ProxyBackendConfiguration backend : backends) {
-            proxyMap.put(backend.getName(), backend.getProxyTo());
-        }
-        updateRoutingTable(routingGroup, proxyMap.keySet());
+    synchronized (lockObject) {
+      if (clusterQueueLengthMap.containsKey(routingGroup)) {
+        Collection<String> knownBackends = new HashSet<String>();
+        knownBackends.addAll(clusterQueueLengthMap.get(routingGroup).keySet());
 
-        String clusterId = getEligibleBackEnd(routingGroup);
-        if (clusterId != null) {
-            return proxyMap.get(clusterId);
+        if (backends.containsAll(knownBackends)) {
+          return;
         } else {
-            int backendId = Math.abs(RANDOM.nextInt()) % backends.size();
-            return backends.get(backendId).getProxyTo();
+          if (knownBackends.removeAll(backends)) {
+            for (String inactiveBackend : knownBackends) {
+              clusterQueueLengthMap.get(routingGroup).remove(inactiveBackend);
+            }
+          }
         }
+      }
+
+      computeWeightsBasedOnQueueLength(clusterQueueLengthMap);
+    }
+  }
+
+  /**
+   * Update routing Table with new Queue Lengths.
+   *
+   * @param updatedQueueLengthMap
+   */
+  public void updateRoutingTable(Map<String, Map<String, Integer>> updatedQueueLengthMap) {
+    synchronized (lockObject) {
+      clusterQueueLengthMap.clear();
+
+      for (String grp : updatedQueueLengthMap.keySet()) {
+        ConcurrentHashMap<String, Integer> queueMap = new ConcurrentHashMap<>();
+        queueMap.putAll(updatedQueueLengthMap.get(grp));
+        clusterQueueLengthMap.put(grp, queueMap);
+      }
+
+      computeWeightsBasedOnQueueLength(clusterQueueLengthMap);
     }
 
+  }
 
-    /**
-     * Performs routing to an adhoc backend based compute weights base don cluster queue depth.
-     *
-     * <p>d.
-     *
-     * @return
-     */
-    public String provideAdhocBackend() {
-        Map<String, String> proxyMap = new HashMap<>();
-        List<ProxyBackendConfiguration> backends = getGatewayBackendManager().getActiveAdhocBackends();
-        if (backends.size() == 0) {
-            throw new IllegalStateException("Number of active backends found zero");
-        }
-
-        for (ProxyBackendConfiguration backend : backends) {
-            proxyMap.put(backend.getName(), backend.getProxyTo());
-        }
-
-        updateRoutingTable("adhoc", proxyMap.keySet());
-
-        String clusterId = getEligibleBackEnd("adhoc");
-        if (clusterId != null) {
-            return proxyMap.get(clusterId);
-        } else {
-            int backendId = Math.abs(RANDOM.nextInt()) % backends.size();
-            return backends.get(backendId).getProxyTo();
-        }
+  /**
+   * A convenience method to peak into the weights used by the routing Manager.
+   *
+   * @param routingGroup
+   * @return
+   */
+  public Map<String, Integer> getInternalWeightedRoutingTable(String routingGroup) {
+    if (!weightedDistributionRouting.containsKey(routingGroup)) {
+      return null;
     }
+    Map<String, Integer> routingTable = new HashMap<>();
+
+    for (Integer wt : weightedDistributionRouting.get(routingGroup).keySet()) {
+      routingTable.put(weightedDistributionRouting.get(routingGroup).get(wt), wt);
+    }
+    return routingTable;
+  }
+
+  /**
+   * A convienience method to get a peak into the state of the routing manager.
+   *
+   * @param routingGroup
+   * @return
+   */
+  public Map<String, Integer> getInternalClusterQueueLength(String routingGroup) {
+    if (!clusterQueueLengthMap.containsKey(routingGroup)) {
+      return null;
+    }
+
+    return clusterQueueLengthMap.get(routingGroup);
+  }
+
+  /**
+   * Looks up the closest weight to random number generated for a given routing group.
+   *
+   * @param routingGroup
+   * @return
+   */
+  public String getEligibleBackEnd(String routingGroup) {
+    if (routingGroupWeightSum.containsKey(routingGroup)
+        && weightedDistributionRouting.containsKey(routingGroup)) {
+      int rnd = RANDOM.nextInt(routingGroupWeightSum.get(routingGroup));
+      return weightedDistributionRouting.get(routingGroup).higherEntry(rnd).getValue();
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Performs routing to a given cluster group. This falls back to an adhoc backend, if no scheduled
+   * backend is found.
+   *
+   * @return
+   */
+  @Override
+  public String provideBackendForRoutingGroup(String routingGroup) {
+    List<ProxyBackendConfiguration> backends =
+        getGatewayBackendManager().getActiveBackends(routingGroup);
+
+    if (backends.isEmpty()) {
+      return provideAdhocBackend();
+    }
+    Map<String, String> proxyMap = new HashMap<>();
+    for (ProxyBackendConfiguration backend : backends) {
+      proxyMap.put(backend.getName(), backend.getProxyTo());
+    }
+    updateRoutingTable(routingGroup, proxyMap.keySet());
+
+    String clusterId = getEligibleBackEnd(routingGroup);
+    if (clusterId != null) {
+      return proxyMap.get(clusterId);
+    } else {
+      int backendId = Math.abs(RANDOM.nextInt()) % backends.size();
+      return backends.get(backendId).getProxyTo();
+    }
+  }
+
+
+  /**
+   * Performs routing to an adhoc backend based compute weights base don cluster queue depth.
+   *
+   * <p>d.
+   *
+   * @return
+   */
+  public String provideAdhocBackend() {
+    Map<String, String> proxyMap = new HashMap<>();
+    List<ProxyBackendConfiguration> backends = getGatewayBackendManager().getActiveAdhocBackends();
+    if (backends.size() == 0) {
+      throw new IllegalStateException("Number of active backends found zero");
+    }
+
+    for (ProxyBackendConfiguration backend : backends) {
+      proxyMap.put(backend.getName(), backend.getProxyTo());
+    }
+
+    updateRoutingTable("adhoc", proxyMap.keySet());
+
+    String clusterId = getEligibleBackEnd("adhoc");
+    if (clusterId != null) {
+      return proxyMap.get(clusterId);
+    } else {
+      int backendId = Math.abs(RANDOM.nextInt()) % backends.size();
+      return backends.get(backendId).getProxyTo();
+    }
+  }
 
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
@@ -78,7 +78,8 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
     } else if (lastButOneQueueLn == 0 || (lastButOneQueueLn == maxQueueLn)) {
       calculatedWtMaxQueue = MIN_WT;
     } else {
-      int lastButOneQueueWt = (int) Math.ceil((MAX_WT - (lastButOneQueueLn * MAX_WT / (double) maxQueueLn)));
+      int lastButOneQueueWt =
+          (int) Math.ceil((MAX_WT - (lastButOneQueueLn * MAX_WT / (double) maxQueueLn)));
       double fractionOfLastWt = (smallestQueueLn / (float) maxQueueLn);
       calculatedWtMaxQueue = (int) Math.ceil(fractionOfLastWt * lastButOneQueueWt);
 
@@ -153,7 +154,8 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
         for (int i = 0; i < numBuckets - 1; i++) {
           // If all clusters have same queue length, assign same wt
           weight = (maxQueueLn == (Integer) queueLengths[i]) ? calculatedWtMaxQueue :
-              (int) Math.ceil(MAX_WT - (((Integer) queueLengths[i] * MAX_WT) / (double) maxQueueLn));
+              (int) Math.ceil(MAX_WT
+                  - (((Integer) queueLengths[i] * MAX_WT) / (double) maxQueueLn));
           sum += weight;
           weightsMap.put(sum, (String) clusterNames[i]);
         }
@@ -313,11 +315,4 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
       return backends.get(backendId).getProxyTo();
     }
   }
-
-
-  public static  void main (String[] args)
-  {
-    System.out.println((int)Math.ceil( 113/(float)112));
-  }
-
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
@@ -1,0 +1,313 @@
+package com.lyft.data.gateway.ha.router;
+
+import com.lyft.data.gateway.ha.clustermonitor.ClusterStats;
+import com.lyft.data.gateway.ha.clustermonitor.PrestoClusterStatsObserver;
+import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A Routing Manager that provides load distribution on to registered active backends based on its queue length.
+ * This manager listens to updates on cluster queue length as recorded by the
+ * {@link com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor}
+ * Ideally where ever a modification is made to the the list of backends(adding, removing) this routing
+ * manager should get notified & updated.
+ * Currently updates are made only on heart beats from
+ * {@link com.lyft.data.gateway.ha.clustermonitor.ActiveClusterMonitor} & during routing requests.
+ */
+@Slf4j
+public class PrestoQueueLengthRoutingTable extends HaRoutingManager implements PrestoClusterStatsObserver {
+    private static final Random RANDOM = new Random();
+    private ConcurrentHashMap<String, Integer> routingGroupWeightSum;
+    private ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>> clusterQueueLengthMap;
+    private Map<String, TreeMap<Integer, String>> weightedDistributionRouting;
+    private final Object lockObject = new Object();
+    private final int MIN_WT = 1;
+    private final int MAX_WT = 100;
+
+
+    public PrestoQueueLengthRoutingTable(GatewayBackendManager gatewayBackendManager, QueryHistoryManager queryHistoryManager) {
+        super(gatewayBackendManager, queryHistoryManager);
+        routingGroupWeightSum = new ConcurrentHashMap<String, Integer>();
+        clusterQueueLengthMap = new ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>>();
+        weightedDistributionRouting = new HashMap<String, TreeMap<Integer, String>>();
+    }
+
+    /**
+     * Uses the queue length of a cluster to assign weights to all active clusters in a routing group.
+     * The weights assigned ensure a fair distribution of routing for queries such that clusters with the least
+     * queue length get assigned more queries.
+     *
+     * @param queueLengthMap
+     */
+    private void computeWeightsBasedOnQueueLength(ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>> queueLengthMap) {
+        synchronized (lockObject) {
+            int sum, queue_sum = 0, weight, num_buckets = 1, equal_distribution = 0, smallest_queue_ln = 0, last_but_one_queue_ln = 0,
+                    max_queue_ln = 0, calculated_wt_max_queue = 0;
+
+            weightedDistributionRouting.clear();
+            routingGroupWeightSum.clear();
+
+            log.debug("Computing Weights for Queue Map " + queueLengthMap.toString());
+
+            for (String routingGroup : queueLengthMap.keySet()) {
+                sum = 0;
+                TreeMap<Integer, String> weightsMap = new TreeMap<>();
+
+                if (queueLengthMap.get(routingGroup).size() == 0) {
+                    log.warn("No active clusters in routingGroup : " + routingGroup + ". Continue to process rest of routing table ");
+                    continue;
+                } else if (queueLengthMap.get(routingGroup).size() == 1) {
+                    log.debug("Routing Group: " + routingGroup + " has only 1 active backend. ");
+                    weightedDistributionRouting.put(routingGroup, new TreeMap<Integer, String>() {{
+                        put(MAX_WT, queueLengthMap.get(routingGroup).keys().nextElement());
+                    }});
+                    routingGroupWeightSum.put(routingGroup, MAX_WT);
+                    continue;
+                }
+
+                Map<String, Integer> sortedByQueueLength = queueLengthMap.get(routingGroup).entrySet().stream().sorted(Comparator.comparing(Map.Entry::getValue))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                                (e1, e2) -> e1, LinkedHashMap::new));
+
+                num_buckets = sortedByQueueLength.size();
+                queue_sum = sortedByQueueLength.values().stream().mapToInt(Integer::intValue).sum();
+                equal_distribution = queue_sum / num_buckets;
+
+                Object[] queueLengths = sortedByQueueLength.values().toArray();
+                Object[] clusterNames = sortedByQueueLength.keySet().toArray();
+
+                smallest_queue_ln = (Integer)queueLengths[0];
+                max_queue_ln = (Integer)queueLengths[queueLengths.length - 1];
+                last_but_one_queue_ln = smallest_queue_ln;
+                if (queueLengths.length > 2) {
+                    last_but_one_queue_ln = (Integer)queueLengths[queueLengths.length - 2];
+                }
+
+                /**
+                 *  All wts are assigned as a fraction of max_queue_ln. Cluster with max_queue_ln should be given least
+                 *  weightage. What this value should be depends on the queueing on the rest of the clusters. since the list
+                 *  is sorted, the smallest_queue_ln & last_but_one_queue_ln give us the range.
+                 *
+                 *  In an ideal situation all clusters should have equals distribution of queries, hence that is used as
+                 *  a threshold to check is a cluster queue is over provisioned or not.
+                 */
+
+                if (max_queue_ln == 0) {
+                    calculated_wt_max_queue = MAX_WT;
+                } else if (last_but_one_queue_ln == 0) {
+                    calculated_wt_max_queue = MIN_WT;
+                } else {
+                    float fraction_of_last_but_one_wt = (last_but_one_queue_ln / (float) max_queue_ln) * (MAX_WT - (last_but_one_queue_ln * MAX_WT / max_queue_ln));
+
+                    if (smallest_queue_ln == 0) {
+                        if (last_but_one_queue_ln < equal_distribution) {
+                            calculated_wt_max_queue = MIN_WT;
+                        } else {
+                            calculated_wt_max_queue = (int)fraction_of_last_but_one_wt;
+                        }
+                    } else if (smallest_queue_ln < equal_distribution) {
+                        if (last_but_one_queue_ln <= equal_distribution) {
+                            calculated_wt_max_queue = (fraction_of_last_but_one_wt / 2 > 0 ) ? (int)fraction_of_last_but_one_wt / 2 : MIN_WT;
+                        } else {
+                            calculated_wt_max_queue = (fraction_of_last_but_one_wt/1.5 > 0) ? (int)(fraction_of_last_but_one_wt/1.5): MIN_WT;
+                        }
+                    } else {
+                        calculated_wt_max_queue = (int)fraction_of_last_but_one_wt;
+                    }
+                }
+
+                for (int i = 0; i < num_buckets - 1; i++) {
+                    // If all clusters have same queue length, assign same wt
+                    weight = (max_queue_ln == (Integer)queueLengths[i]) ? calculated_wt_max_queue : MAX_WT - (((Integer)queueLengths[i] * MAX_WT) / max_queue_ln);
+                    sum += weight;
+                    weightsMap.put(sum, (String) clusterNames[i]);
+                }
+
+                sum += calculated_wt_max_queue;
+                weightsMap.put(sum, (String)clusterNames[num_buckets - 1]);
+
+                weightedDistributionRouting.put(routingGroup, weightsMap);
+                routingGroupWeightSum.put(routingGroup, sum);
+            }
+
+            if (log.isDebugEnabled()) {
+                for (String rg : weightedDistributionRouting.keySet()) {
+                    log.debug(String.format("Routing Table for : {%s} is {%s}", rg, weightedDistributionRouting.get(rg).toString()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Update the Routing Table only if a previously known backend has been deactivated.
+     * Newly added backends are handled through {@link PrestoQueueLengthRoutingTable#updateRoutingTable(Map)}
+     * updateRoutingTable}
+     *
+     * @param routingGroup
+     * @param backends
+     */
+    protected void updateRoutingTable(String routingGroup, Set<String> backends) {
+
+        synchronized (lockObject) {
+            if (clusterQueueLengthMap.containsKey(routingGroup)) {
+                Collection<String> knownBackends = new HashSet<String>();
+                knownBackends.addAll(clusterQueueLengthMap.get(routingGroup).keySet());
+
+                if (backends.containsAll(knownBackends)) {
+                    return;
+                } else {
+                    if (knownBackends.removeAll(backends)) {
+                        for (String inactiveBackend : knownBackends) {
+                            clusterQueueLengthMap.get(routingGroup).remove(inactiveBackend);
+                        }
+                    }
+                }
+            }
+
+            computeWeightsBasedOnQueueLength(clusterQueueLengthMap);
+        }
+    }
+
+    /**
+     * Update routing Table with new Queue Lengths
+     *
+     * @param updatedQueueLengthMap
+     */
+    protected void updateRoutingTable(Map<String, Map<String, Integer>> updatedQueueLengthMap) {
+        synchronized (lockObject) {
+            clusterQueueLengthMap.clear();
+
+            for (String grp : updatedQueueLengthMap.keySet()) {
+                ConcurrentHashMap<String, Integer> queueMap = new ConcurrentHashMap<>();
+                queueMap.putAll(updatedQueueLengthMap.get(grp));
+                clusterQueueLengthMap.put(grp, queueMap);
+            }
+
+            computeWeightsBasedOnQueueLength(clusterQueueLengthMap);
+        }
+
+    }
+
+    /**
+     * @param routingGroup
+     * @return
+     */
+    public Map<String, Integer> getInternalWeightedRoutingTable(String routingGroup) {
+        if (!weightedDistributionRouting.containsKey(routingGroup))
+            return null;
+        Map<String, Integer> routingTable = new HashMap<>();
+
+        for (Integer wt : weightedDistributionRouting.get(routingGroup).keySet()) {
+            routingTable.put(weightedDistributionRouting.get(routingGroup).get(wt), wt);
+        }
+        return routingTable;
+    }
+
+    /**
+     * @param routingGroup
+     * @return
+     */
+    public Map<String, Integer> getInternalClusterQueueLength(String routingGroup) {
+        if (!clusterQueueLengthMap.containsKey(routingGroup))
+            return null;
+
+        return clusterQueueLengthMap.get(routingGroup);
+    }
+
+    /**
+     * Looks up the closest weight to random number generated for a given routing group.
+     *
+     * @param routingGroup
+     * @return
+     */
+    public String getEligibleBackEnd(String routingGroup) {
+        if (routingGroupWeightSum.containsKey(routingGroup) && weightedDistributionRouting.containsKey(routingGroup)) {
+            int rnd = RANDOM.nextInt(routingGroupWeightSum.get(routingGroup));
+            return weightedDistributionRouting.get(routingGroup).higherEntry(rnd).getValue();
+        } else
+            return null;
+    }
+
+
+    @Override
+    public void observe(List<ClusterStats> stats) {
+        Map<String, Map<String, Integer>> clusterQueueMap = new HashMap<String, Map<String, Integer>>();
+
+        for (ClusterStats stat : stats) {
+            if (!clusterQueueMap.containsKey(stat.getRoutingGroup())) {
+                clusterQueueMap.put(stat.getRoutingGroup(), new HashMap<String, Integer>() {{
+                    put(stat.getClusterId(), stat.getQueuedQueryCount());
+                }});
+            } else {
+                clusterQueueMap.get(stat.getRoutingGroup()).put(stat.getClusterId(), stat.getQueuedQueryCount());
+            }
+        }
+
+        updateRoutingTable(clusterQueueMap);
+    }
+
+    /**
+     * Performs routing to a given cluster group. This falls back to an adhoc backend, if no scheduled
+     * backend is found.
+     *
+     * @return
+     */
+    @Override
+    public String provideBackendForRoutingGroup(String routingGroup) {
+        List<ProxyBackendConfiguration> backends =
+                getGatewayBackendManager().getActiveBackends(routingGroup);
+
+        if (backends.isEmpty()) {
+            return provideAdhocBackend();
+        }
+        Map<String, String> proxyMap = new HashMap<>();
+        for (ProxyBackendConfiguration backend : backends) {
+            proxyMap.put(backend.getName(), backend.getProxyTo());
+        }
+        updateRoutingTable(routingGroup, proxyMap.keySet());
+
+        String clusterId = getEligibleBackEnd(routingGroup);
+        if (clusterId != null) {
+            return proxyMap.get(clusterId);
+        } else {
+            int backendId = Math.abs(RANDOM.nextInt()) % backends.size();
+            return backends.get(backendId).getProxyTo();
+        }
+    }
+
+
+    /**
+     * Performs routing to an adhoc backend based compute weights base don cluster queue depth.
+     *
+     * <p>d.
+     *
+     * @return
+     */
+    public String provideAdhocBackend() {
+        Map<String, String> proxyMap = new HashMap<>();
+        List<ProxyBackendConfiguration> backends = getGatewayBackendManager().getActiveAdhocBackends();
+        if (backends.size() == 0) {
+            throw new IllegalStateException("Number of active backends found zero");
+        }
+
+        for (ProxyBackendConfiguration backend : backends) {
+            proxyMap.put(backend.getName(), backend.getProxyTo());
+        }
+
+        updateRoutingTable("adhoc", proxyMap.keySet());
+
+        String clusterId = getEligibleBackEnd("adhoc");
+        if (clusterId != null) {
+            return proxyMap.get(clusterId);
+        } else {
+            int backendId = Math.abs(RANDOM.nextInt()) % backends.size();
+            return backends.get(backendId).getProxyTo();
+        }
+    }
+
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/QueryHistoryManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/QueryHistoryManager.java
@@ -10,6 +10,8 @@ public interface QueryHistoryManager {
 
   List<QueryDetail> fetchQueryHistory();
 
+  String getBackendForQueryId(String queryId);
+
   @Data
   @ToString
   class QueryDetail implements Comparable<QueryDetail> {

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -193,17 +193,15 @@ public class TestPrestoQueueLengthRoutingTable {
         //    + " Internal Routing table: "
         //    + routingTable.getInternalWeightedRoutingTable(mockRoutingGroup).toString()
         //    + " Distribution: " + routingDistribution.toString());
-        if (numBk > 1) {
-          if (routingDistribution.containsKey(mockRoutingGroup + (numBk - 1))) {
-            assert routingDistribution.get(mockRoutingGroup + (numBk - 1))
-                <= Math.ceil(numRequests / numBk);
-          } else {
-            assert routingDistribution.values().stream().mapToInt(Integer::intValue).sum()
-                == numRequests;
-          }
-        } else {
-          assert routingDistribution.get(mockRoutingGroup + '0') == numRequests;
+        if (numBk > 2 && routingDistribution.containsKey(mockRoutingGroup + (numBk - 1))) {
+          assert routingDistribution.get(mockRoutingGroup + (numBk - 1))
+              <= Math.ceil(numRequests / numBk);
+        } else  {
+          assert routingDistribution.values().stream().mapToInt(Integer::intValue).sum()
+              == numRequests;
         }
+
+
       }
     }
   }

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -1,6 +1,5 @@
 package com.lyft.data.gateway.ha.router;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.lyft.data.gateway.ha.HaGatewayTestUtils;
@@ -9,10 +8,8 @@ import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
 import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
 import java.io.File;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -107,7 +104,7 @@ public class TestPrestoQueueLengthRoutingTable {
   }
 
   private void registerBackEnds(String groupName, int numBackends,
-                                   int queueLengthDistributiveFactor) {
+                                int queueLengthDistributiveFactor) {
     int mockQueueLength = 0;
     String backend;
 
@@ -159,11 +156,11 @@ public class TestPrestoQueueLengthRoutingTable {
         Map<String, Integer> routingDistribution = routeQueries(mockRoutingGroup, numRequests);
 
         // Useful for debugging
-        System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:"
-            + numRequests
-            + " Internal Routing table: "
-            + routingTable.getInternalWeightedRoutingTable(mockRoutingGroup).toString()
-            + " Distribution: " + routingDistribution.toString());
+        //System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:"
+        //    + numRequests
+        //    + " Internal Routing table: "
+        //    + routingTable.getInternalWeightedRoutingTable(mockRoutingGroup).toString()
+        //    + " Distribution: " + routingDistribution.toString());
         if (numBk > 1) {
           if (routingDistribution.containsKey(mockRoutingGroup + (numBk - 1))) {
             assert routingDistribution.get(mockRoutingGroup + (numBk - 1))
@@ -191,11 +188,11 @@ public class TestPrestoQueueLengthRoutingTable {
         Map<String, Integer> routingDistribution = routeQueries(mockRoutingGroup, numRequests);
 
         // Useful Debugging Info
-        System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:"
-            + numRequests
-            + " Internal Routing table: "
-            + routingTable.getInternalWeightedRoutingTable(mockRoutingGroup).toString()
-            + " Distribution: " + routingDistribution.toString());
+        //System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:"
+        //    + numRequests
+        //    + " Internal Routing table: "
+        //    + routingTable.getInternalWeightedRoutingTable(mockRoutingGroup).toString()
+        //    + " Distribution: " + routingDistribution.toString());
         if (numBk > 1) {
           if (routingDistribution.containsKey(mockRoutingGroup + (numBk - 1))) {
             assert routingDistribution.get(mockRoutingGroup + (numBk - 1))
@@ -222,16 +219,16 @@ public class TestPrestoQueueLengthRoutingTable {
         Map<String, Integer> routingDistribution = routeQueries(mockRoutingGroup, numRequests);
 
         //Useful Debugging Info
-        System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:" +
-        numRequests
-        + " Internal Routing table: " + routingTable.getInternalWeightedRoutingTable
-        (mockRoutingGroup).toString()
-        + " Distribution: " + routingDistribution.toString());
+        //System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:" +
+        //numRequests
+        //+ " Internal Routing table: " + routingTable.getInternalWeightedRoutingTable
+        //(mockRoutingGroup).toString()
+        //+ " Distribution: " + routingDistribution.toString());
 
         if (numBk > 1) {
           // With equal weights, the algorithm randomly chooses from the list. Check that the
           // distribution spans atleast half of the routing group.
-          assert routingDistribution.size() >= clusterQueueMap.get(mockRoutingGroup).size()/2;
+          assert routingDistribution.size() >= clusterQueueMap.get(mockRoutingGroup).size() / 2;
         } else {
           assert routingDistribution.get(mockRoutingGroup + '0') == numRequests;
         }
@@ -250,11 +247,11 @@ public class TestPrestoQueueLengthRoutingTable {
       Map<String, Integer> routingDistribution = routeQueries(grp, numRequests);
 
       // Useful for debugging
-      System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:" +
-      numRequests
-      + " Internal Routing table: " + routingTable.getInternalWeightedRoutingTable
-      (grp).toString()
-      + " Distribution: " + routingDistribution.toString());
+      //System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:" +
+      //numRequests
+      //+ " Internal Routing table: " + routingTable.getInternalWeightedRoutingTable
+      //(grp).toString()
+      //+ " Distribution: " + routingDistribution.toString());
       if (numBk > 1) {
         if (routingDistribution.containsKey(grp + (numBk - 1))) {
           assert routingDistribution.get(grp + (numBk - 1))

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -1,148 +1,314 @@
 package com.lyft.data.gateway.ha.router;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import com.lyft.data.gateway.ha.HaGatewayTestUtils;
 import com.lyft.data.gateway.ha.config.DataStoreConfiguration;
 import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
 import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
+import java.io.File;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-
 @Test
 public class TestPrestoQueueLengthRoutingTable {
-    PrestoQueueLengthRoutingTable routingTable;
-    GatewayBackendManager backendManager;
-    QueryHistoryManager historyManager;
-    String[] mockAdhocBackeds = {"adhoc0"};
-    String mockRoutingGroup = "adhoc";
-    Map<String, Map<String, Integer>> clusterQueueMap;
-    final int[] QUERY_VOLUMES = {15, 50, 100, 200};
-    final int NUM_BACKENDS = 5;
+  static final int[] QUERY_VOLUMES = {15, 50, 100, 200};
+  static final int NUM_BACKENDS = 5;
+  PrestoQueueLengthRoutingTable routingTable;
+  GatewayBackendManager backendManager;
+  QueryHistoryManager historyManager;
+  String[] mockRoutingGroups = {"adhoc", "scheduled"};
+  String mockRoutingGroup = "adhoc";
+  Map<String, Map<String, Integer>> clusterQueueMap;
 
-    @BeforeClass(alwaysRun = true)
-    public void setUp() {
-        File baseDir = new File(System.getProperty("java.io.tmpdir"));
-        File tempH2DbDir = new File(baseDir, "h2db-" + System.currentTimeMillis());
-        tempH2DbDir.deleteOnExit();
-        String jdbcUrl = "jdbc:h2:" + tempH2DbDir.getAbsolutePath();
-        HaGatewayTestUtils.seedRequiredData(
-                new HaGatewayTestUtils.TestConfig("", tempH2DbDir.getAbsolutePath()));
-        DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver");
-        JdbcConnectionManager connectionManager = new JdbcConnectionManager(db);
-        backendManager = new HaGatewayManager(connectionManager);
-        historyManager = new HaQueryHistoryManager(connectionManager) {
-        };
-        routingTable = new PrestoQueueLengthRoutingTable(backendManager, historyManager);
-        addMockBackends(NUM_BACKENDS, 0);
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    File baseDir = new File(System.getProperty("java.io.tmpdir"));
+    File tempH2DbDir = new File(baseDir, "h2db-" + System.currentTimeMillis());
+    tempH2DbDir.deleteOnExit();
+    String jdbcUrl = "jdbc:h2:" + tempH2DbDir.getAbsolutePath();
+    HaGatewayTestUtils.seedRequiredData(
+        new HaGatewayTestUtils.TestConfig("", tempH2DbDir.getAbsolutePath()));
+    DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver");
+    JdbcConnectionManager connectionManager = new JdbcConnectionManager(db);
+    backendManager = new HaGatewayManager(connectionManager);
+    historyManager = new HaQueryHistoryManager(connectionManager) {
+    };
+    routingTable = new PrestoQueueLengthRoutingTable(backendManager, historyManager);
+
+    for (String grp : mockRoutingGroups) {
+      addMockBackends(grp, NUM_BACKENDS, 0);
+    }
+  }
+
+  private void deactiveAllBackends() {
+    for (int i = 0; i < NUM_BACKENDS; i++) {
+      backendManager.deactivateBackend(mockRoutingGroup + i);
+    }
+    clusterQueueMap = new HashMap<>();
+  }
+
+  private void addMockBackends(String groupName, int numBackends,
+                               int queueLengthDistributiveFactor) {
+    String backend = null;
+
+    for (int i = 0; i < numBackends; i++) {
+      backend = groupName + i;
+      ProxyBackendConfiguration proxyBackend = new ProxyBackendConfiguration();
+      proxyBackend.setActive(true);
+      proxyBackend.setRoutingGroup(groupName);
+      proxyBackend.setName(backend);
+      proxyBackend.setProxyTo(backend + ".presto.lyft.com");
+      backendManager.addBackend(proxyBackend);
+    }
+  }
+
+  private void registerBackEndsWithRandomQueueLength(String groupName, int numBackends) {
+    int mockQueueLength = 0;
+    String backend;
+    int maxLength = 200;
+    Random generator = new Random();
+
+    Map<String, Integer> queueLenghts = new HashMap<>();
+
+    for (int i = 0; i < numBackends; i++) {
+      backend = groupName + i;
+      backendManager.activateBackend(backend);
+      queueLenghts.put(backend, generator.nextInt(maxLength));
     }
 
-    private void deactiveAllBackends() {
-        for (int i = 0; i < NUM_BACKENDS; i++) {
-            backendManager.deactivateBackend(mockRoutingGroup + i);
+    clusterQueueMap.put(groupName, queueLenghts);
+    routingTable.updateRoutingTable(clusterQueueMap);
+  }
+
+  private void registerBackEnds(String groupName, int numBackends,
+                                int queueLengthDistributiveFactor) {
+    int mockQueueLength = 0;
+    String backend;
+
+    Map<String, Integer> queueLenghts = new HashMap<>();
+
+    for (int i = 0; i < numBackends; i++) {
+      backend = groupName + i;
+      backendManager.activateBackend(backend);
+      queueLenghts.put(backend, mockQueueLength += queueLengthDistributiveFactor);
+    }
+
+    clusterQueueMap.put(groupName, queueLenghts);
+    routingTable.updateRoutingTable(clusterQueueMap);
+  }
+
+  private void resetBackends(String groupName, int numBk, int queueDistribution) {
+    deactiveAllBackends();
+    registerBackEnds(groupName, numBk, queueDistribution);
+  }
+
+  private Map<String, Integer> routeQueries(String groupName, int numRequests) {
+    String eligibleBackend;
+    int sum = 0;
+    Map<String, Integer> routingDistribution = new HashMap<String, Integer>();
+
+
+    for (int i = 0; i < numRequests; i++) {
+      eligibleBackend = routingTable.getEligibleBackEnd(groupName);
+
+      if (!routingDistribution.containsKey(eligibleBackend)) {
+        routingDistribution.put(eligibleBackend, 1);
+      } else {
+        sum = routingDistribution.get(eligibleBackend) + 1;
+        routingDistribution.put(eligibleBackend, sum);
+      }
+    }
+    return routingDistribution;
+  }
+
+  @Test
+  public void testRoutingWithEvenWeightDistribution() {
+
+    int queueDistribution = 3;
+
+    for (int numRequests : QUERY_VOLUMES) {
+      for (int numBk = 1; numBk <= NUM_BACKENDS; numBk++) {
+
+        resetBackends(mockRoutingGroup, numBk, queueDistribution);
+        Map<String, Integer> routingDistribution = routeQueries(mockRoutingGroup, numRequests);
+
+        // Useful for debugging
+        System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:"
+            + numRequests
+            + " Internal Routing table: "
+            + routingTable.getInternalWeightedRoutingTable(mockRoutingGroup).toString()
+            + " Distribution: " + routingDistribution.toString());
+        if (numBk > 1) {
+          if (routingDistribution.containsKey(mockRoutingGroup + (numBk - 1))) {
+            assert routingDistribution.get(mockRoutingGroup + (numBk - 1))
+                <= Math.ceil(numRequests / numBk);
+          } else {
+            assert routingDistribution.values().stream().mapToInt(Integer::intValue).sum()
+                == numRequests;
+          }
+        } else {
+          assert routingDistribution.get(mockRoutingGroup + '0') == numRequests;
         }
+      }
     }
 
-    private void addMockBackends(int num_backends, int queueLengthDistributiveFactor) {
-        String backend = null;
-        clusterQueueMap = new HashMap<>();
+  }
 
-        for (int i = 0; i < num_backends; i++) {
-            backend = mockRoutingGroup + i;
-            ProxyBackendConfiguration proxyBackend = new ProxyBackendConfiguration();
-            proxyBackend.setActive(true);
-            proxyBackend.setRoutingGroup(mockRoutingGroup);
-            proxyBackend.setName(backend);
-            proxyBackend.setProxyTo(backend + ".presto.lyft.com");
-            backendManager.addBackend(proxyBackend);
+  @Test
+  public void testRoutingWithSkewedWeightDistribution() {
+    int queueDistribution = 30;
+    for (int numRequests : QUERY_VOLUMES) {
+      for (int numBk = 1; numBk <= NUM_BACKENDS; numBk++) {
+
+        resetBackends(mockRoutingGroup, numBk, queueDistribution);
+        Map<String, Integer> routingDistribution = routeQueries(mockRoutingGroup, numRequests);
+
+        // Useful Debugging Info
+        //System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:"
+        //    + numRequests
+        //    + " Internal Routing table: "
+        //    + routingTable.getInternalWeightedRoutingTable(mockRoutingGroup).toString()
+        //    + " Distribution: " + routingDistribution.toString());
+        if (numBk > 1) {
+          if (routingDistribution.containsKey(mockRoutingGroup + (numBk - 1))) {
+            assert routingDistribution.get(mockRoutingGroup + (numBk - 1))
+                <= Math.ceil(numRequests / numBk);
+          } else {
+            assert routingDistribution.values().stream().mapToInt(Integer::intValue).sum()
+                == numRequests;
+          }
+        } else {
+          assert routingDistribution.get(mockRoutingGroup + '0') == numRequests;
         }
+      }
     }
+  }
 
-    private void registerBackEnds(int num_backends, int queueLengthDistributiveFactor) {
-        clusterQueueMap = new HashMap<String, Map<String, Integer>>();
-        Map<String, Integer> queueLenghts = new HashMap<>();
-        int mockQueueLength = 0;
-        String backend;
-        for (int i = 0; i < num_backends; i++) {
-            backend = mockRoutingGroup + i;
-            backendManager.activateBackend(mockRoutingGroup + i);
-            queueLenghts.put(backend, mockQueueLength += queueLengthDistributiveFactor);
+  @Test
+  public void testRoutingWithEqualWeightDistribution() {
+    int queueDistribution = 0;
+
+    for (int numRequests : QUERY_VOLUMES) {
+      for (int numBk = 1; numBk <= NUM_BACKENDS; numBk++) {
+
+        resetBackends(mockRoutingGroup, numBk, queueDistribution);
+        Map<String, Integer> routingDistribution = routeQueries(mockRoutingGroup, numRequests);
+
+        //Useful Debugging Info
+        //System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:" +
+        //numRequests
+        //+ " Internal Routing table: " + routingTable.getInternalWeightedRoutingTable
+        //(mockRoutingGroup).toString()
+        //+ " Distribution: " + routingDistribution.toString());
+
+        if (numBk > 1) {
+          // With equal weights, the algorithm randomly chooses from the list.
+          assert routingDistribution.size() == clusterQueueMap.get(mockRoutingGroup).size();
+        } else {
+          assert routingDistribution.get(mockRoutingGroup + '0') == numRequests;
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testRoutingWithMultipleGroups() {
+    int queueDistribution = 10;
+    int numRequests = 50;
+    int numBk = 3;
+
+    for (String grp : mockRoutingGroups) {
+      resetBackends(grp, numBk, queueDistribution);
+      Map<String, Integer> routingDistribution = routeQueries(grp, numRequests);
+
+      // Useful for debugging
+      //System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:" +
+      //numRequests
+      //+ " Internal Routing table: " + routingTable.getInternalWeightedRoutingTable
+      //(mockRoutingGroup).toString()
+      //+ " Distribution: " + routingDistribution.toString());
+      if (numBk > 1) {
+        if (routingDistribution.containsKey(grp + (numBk - 1))) {
+          assert routingDistribution.get(grp + (numBk - 1))
+              <= Math.ceil(numRequests / numBk);
+        } else {
+          assert routingDistribution.values().stream().mapToInt(Integer::intValue).sum()
+              == numRequests;
+        }
+      } else {
+        assert routingDistribution.get(grp + '0') == numRequests;
+      }
+    }
+  }
+
+  @Test
+  public void testActiveClusterMonitorUpdateAndRouting() throws InterruptedException {
+    int numRequests = 10;
+    int numBatches = 10;
+    int sum = 0;
+    int numBk = 3;
+
+    AtomicBoolean globalToggle = new AtomicBoolean(true);
+    Map<String, Integer> routingDistribution = new HashMap<>();
+    Map<String, Integer> totalDistribution = new HashMap<>();
+
+    ScheduledExecutorService scheduler =
+        Executors.newScheduledThreadPool(1);
+
+    final Runnable activeClusterMonitor = () -> {
+      Map<String, Integer> queueLenghts = new HashMap<>();
+      String backend;
+      int queueLen = 0;
+      for (int i = 0; i < numBk; i++) {
+        backend = mockRoutingGroup + i;
+        if (globalToggle.get()) {
+          queueLen = (i < Math.ceil((float) numBk / 2)) ? 0 : 100;
+        } else {
+          queueLen = (i < Math.floor((float) numBk / 2)) ? 100 : 75;
         }
 
-        clusterQueueMap.put(mockRoutingGroup, queueLenghts);
-        routingTable.updateRoutingTable(clusterQueueMap);
-    }
+        queueLenghts.put(backend, queueLen);
+      }
+      globalToggle.set(!globalToggle.get());
+      clusterQueueMap.put(mockRoutingGroup, queueLenghts);
+      routingTable.updateRoutingTable(clusterQueueMap);
+    };
 
-    private Map<String, Integer> routeQueries(int num_bk, int queueDistribution, int num_requests) {
-        String eligibleBackend;
-        int sum = 0;
-        Map<String, Integer> routingDistribution = new HashMap<String, Integer>();
-        deactiveAllBackends();
-        registerBackEnds(num_bk, queueDistribution);
+    resetBackends(mockRoutingGroup, numBk, 0);
+    scheduler.scheduleAtFixedRate(activeClusterMonitor, 0, 1, SECONDS);
 
-        for (int i = 0; i < num_requests; i++) {
-            eligibleBackend = routingTable.getEligibleBackEnd(mockRoutingGroup);
 
-            if (!routingDistribution.containsKey(eligibleBackend)) {
-                routingDistribution.put(eligibleBackend, 1);
-            } else {
-                sum = routingDistribution.get(eligibleBackend) + 1;
-                routingDistribution.put(eligibleBackend, sum);
-            }
+    for (int batch = 0; batch < numBatches; batch++) {
+      routingDistribution = routeQueries(mockRoutingGroup, numRequests);
+      if (batch == 0) {
+        totalDistribution.putAll(routingDistribution);
+      } else {
+        for (String key : routingDistribution.keySet()) {
+          sum = totalDistribution.get(key) + routingDistribution.get(key);
+          totalDistribution.put(key, sum);
         }
-        return routingDistribution;
+      }
+      // Some random amount of sleep time
+      Thread.sleep(270);
     }
 
-    @Test
-    public void testRoutingWithEvenWeightDistribution() {
-
-        int queueDistribution = 3;
-
-        for (int num_requests : QUERY_VOLUMES) {
-            for (int num_bk = 1; num_bk <= NUM_BACKENDS; num_bk++) {
-
-                Map<String, Integer> routingDistribution = routeQueries(num_bk, queueDistribution, num_requests);
-
-                System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:" + num_requests
-                        + " Internal Routing table: " + routingTable.getInternalWeightedRoutingTable(mockRoutingGroup).toString()
-                        + " Distribution: " + routingDistribution.toString());
-                if (num_bk > 1) {
-
-                    if (routingDistribution.containsKey(mockRoutingGroup + (num_bk - 1)))
-                        assert routingDistribution.get(mockRoutingGroup + (num_bk - 1)) <= Math.ceil(num_requests / num_bk);
-                    else
-                        assert routingDistribution.values().stream().mapToInt(Integer::intValue).sum() == num_requests;
-                } else
-                    assert routingDistribution.get(mockRoutingGroup + '0') == num_requests;
-            }
-        }
-
-    }
-
-    @Test
-    public void testRoutingWithSkewedWeightDistribution() {
-        int queueDistribution = 30;
-
-        for (int num_requests : QUERY_VOLUMES) {
-            for (int num_bk = 1; num_bk <= NUM_BACKENDS; num_bk++) {
-
-                Map<String, Integer> routingDistribution = routeQueries(num_bk, queueDistribution, num_requests);
-
-                System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:" + num_requests
-                        + " Internal Routing table: " + routingTable.getInternalWeightedRoutingTable(mockRoutingGroup).toString()
-                        + " Distribution: " + routingDistribution.toString());
-                if (num_bk > 1) {
-                    if (routingDistribution.containsKey(mockRoutingGroup + (num_bk - 1)))
-                        assert routingDistribution.get(mockRoutingGroup + (num_bk - 1)) <= Math.ceil(num_requests / num_bk);
-                    else
-                        assert routingDistribution.values().stream().mapToInt(Integer::intValue).sum() == num_requests;
-                } else
-                    assert routingDistribution.get(mockRoutingGroup + '0') == num_requests;
-            }
-        }
-    }
-
+    System.out.println("Total Requests :" + numBatches * numRequests
+        + " distribution :" + totalDistribution.toString());
+    assert totalDistribution.get(mockRoutingGroup + (numBk - 1))
+        <= (numBatches * numRequests / numBk);
+    scheduler.shutdown();
+  }
 
 }
+
+

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -1,0 +1,148 @@
+package com.lyft.data.gateway.ha.router;
+
+import com.lyft.data.gateway.ha.HaGatewayTestUtils;
+import com.lyft.data.gateway.ha.config.DataStoreConfiguration;
+import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
+import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+@Test
+public class TestPrestoQueueLengthRoutingTable {
+    PrestoQueueLengthRoutingTable routingTable;
+    GatewayBackendManager backendManager;
+    QueryHistoryManager historyManager;
+    String[] mockAdhocBackeds = {"adhoc0"};
+    String mockRoutingGroup = "adhoc";
+    Map<String, Map<String, Integer>> clusterQueueMap;
+    final int[] QUERY_VOLUMES = {15, 50, 100, 200};
+    final int NUM_BACKENDS = 5;
+
+    @BeforeClass(alwaysRun = true)
+    public void setUp() {
+        File baseDir = new File(System.getProperty("java.io.tmpdir"));
+        File tempH2DbDir = new File(baseDir, "h2db-" + System.currentTimeMillis());
+        tempH2DbDir.deleteOnExit();
+        String jdbcUrl = "jdbc:h2:" + tempH2DbDir.getAbsolutePath();
+        HaGatewayTestUtils.seedRequiredData(
+                new HaGatewayTestUtils.TestConfig("", tempH2DbDir.getAbsolutePath()));
+        DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver");
+        JdbcConnectionManager connectionManager = new JdbcConnectionManager(db);
+        backendManager = new HaGatewayManager(connectionManager);
+        historyManager = new HaQueryHistoryManager(connectionManager) {
+        };
+        routingTable = new PrestoQueueLengthRoutingTable(backendManager, historyManager);
+        addMockBackends(NUM_BACKENDS, 0);
+    }
+
+    private void deactiveAllBackends() {
+        for (int i = 0; i < NUM_BACKENDS; i++) {
+            backendManager.deactivateBackend(mockRoutingGroup + i);
+        }
+    }
+
+    private void addMockBackends(int num_backends, int queueLengthDistributiveFactor) {
+        String backend = null;
+        clusterQueueMap = new HashMap<>();
+
+        for (int i = 0; i < num_backends; i++) {
+            backend = mockRoutingGroup + i;
+            ProxyBackendConfiguration proxyBackend = new ProxyBackendConfiguration();
+            proxyBackend.setActive(true);
+            proxyBackend.setRoutingGroup(mockRoutingGroup);
+            proxyBackend.setName(backend);
+            proxyBackend.setProxyTo(backend + ".presto.lyft.com");
+            backendManager.addBackend(proxyBackend);
+        }
+    }
+
+    private void registerBackEnds(int num_backends, int queueLengthDistributiveFactor) {
+        clusterQueueMap = new HashMap<String, Map<String, Integer>>();
+        Map<String, Integer> queueLenghts = new HashMap<>();
+        int mockQueueLength = 0;
+        String backend;
+        for (int i = 0; i < num_backends; i++) {
+            backend = mockRoutingGroup + i;
+            backendManager.activateBackend(mockRoutingGroup + i);
+            queueLenghts.put(backend, mockQueueLength += queueLengthDistributiveFactor);
+        }
+
+        clusterQueueMap.put(mockRoutingGroup, queueLenghts);
+        routingTable.updateRoutingTable(clusterQueueMap);
+    }
+
+    private Map<String, Integer> routeQueries(int num_bk, int queueDistribution, int num_requests) {
+        String eligibleBackend;
+        int sum = 0;
+        Map<String, Integer> routingDistribution = new HashMap<String, Integer>();
+        deactiveAllBackends();
+        registerBackEnds(num_bk, queueDistribution);
+
+        for (int i = 0; i < num_requests; i++) {
+            eligibleBackend = routingTable.getEligibleBackEnd(mockRoutingGroup);
+
+            if (!routingDistribution.containsKey(eligibleBackend)) {
+                routingDistribution.put(eligibleBackend, 1);
+            } else {
+                sum = routingDistribution.get(eligibleBackend) + 1;
+                routingDistribution.put(eligibleBackend, sum);
+            }
+        }
+        return routingDistribution;
+    }
+
+    @Test
+    public void testRoutingWithEvenWeightDistribution() {
+
+        int queueDistribution = 3;
+
+        for (int num_requests : QUERY_VOLUMES) {
+            for (int num_bk = 1; num_bk <= NUM_BACKENDS; num_bk++) {
+
+                Map<String, Integer> routingDistribution = routeQueries(num_bk, queueDistribution, num_requests);
+
+                System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:" + num_requests
+                        + " Internal Routing table: " + routingTable.getInternalWeightedRoutingTable(mockRoutingGroup).toString()
+                        + " Distribution: " + routingDistribution.toString());
+                if (num_bk > 1) {
+
+                    if (routingDistribution.containsKey(mockRoutingGroup + (num_bk - 1)))
+                        assert routingDistribution.get(mockRoutingGroup + (num_bk - 1)) <= Math.ceil(num_requests / num_bk);
+                    else
+                        assert routingDistribution.values().stream().mapToInt(Integer::intValue).sum() == num_requests;
+                } else
+                    assert routingDistribution.get(mockRoutingGroup + '0') == num_requests;
+            }
+        }
+
+    }
+
+    @Test
+    public void testRoutingWithSkewedWeightDistribution() {
+        int queueDistribution = 30;
+
+        for (int num_requests : QUERY_VOLUMES) {
+            for (int num_bk = 1; num_bk <= NUM_BACKENDS; num_bk++) {
+
+                Map<String, Integer> routingDistribution = routeQueries(num_bk, queueDistribution, num_requests);
+
+                System.out.println("Input :" + clusterQueueMap.toString() + " Num of Requests:" + num_requests
+                        + " Internal Routing table: " + routingTable.getInternalWeightedRoutingTable(mockRoutingGroup).toString()
+                        + " Distribution: " + routingDistribution.toString());
+                if (num_bk > 1) {
+                    if (routingDistribution.containsKey(mockRoutingGroup + (num_bk - 1)))
+                        assert routingDistribution.get(mockRoutingGroup + (num_bk - 1)) <= Math.ceil(num_requests / num_bk);
+                    else
+                        assert routingDistribution.values().stream().mapToInt(Integer::intValue).sum() == num_requests;
+                } else
+                    assert routingDistribution.get(mockRoutingGroup + '0') == num_requests;
+            }
+        }
+    }
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.6.6</version>
+    <version>1.6.7</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.6.6</version>
+        <version>1.6.7</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
1. Introduced Listeners for the Active Cluster Monitor , The Health Checker & RoutingTable are listners to the stats collected frm the Active Cluster Monitor.
2. The PrestoQueueLengthRoutingTable is an extention of the HARoutingManager that gets list of all active backends along with queue depth. It assigns a weight to each cluster relative to the most queued up cluster. The most queued up cluster's weight is adjusted such that it handles the following cases
a. There is a huge difference between the least queued up & most queued up cluster, in which case the most queued Up cluster is given a negligible wt such that it almost get no new requests.
b. there diff is not huge between least & most queued up in which case most queued Up cluster is given a small-ish  wt such that it get sonly a few requests in favor of the other healthier clusters.
c. All clusters have equal load OR 0 load , at which point its a even distribution. 




With this new refactor, when users want to Use the ActiveClusterMonitor managed App, make sure to also add the module ClusterStateListenerModule to gateway-ha-config.yml