### PR TITLE
Add metrics logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
         <jetty.version>9.4.9.v20180320</jetty.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <lombok.version>1.16.20</lombok.version>
+        <lombok.version>1.18.10</lombok.version>
         <testng.version>6.10</testng.version>
         <mockwebserver.version>1.2.1</mockwebserver.version>
 


### PR DESCRIPTION
For https://jira.lyft.net/browse/DATA-9315, added logging for non 200 responses to help debugging issues with health check failures.

Also bumped up Lombok version so it works with JDK10+ due to https://github.com/rzwitserloot/lombok/issues/1651