### PR TITLE
whitelist cluster api for presto ui

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -28,6 +28,7 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
   public static final String V1_STATEMENT_PATH = "/v1/statement";
   public static final String V1_QUERY_PATH = "/v1/query";
   public static final String V1_INFO_PATH = "/v1/info";
+  public static final String V1_CLUSTER_PATH = "/v1/cluster";
   public static final String PRESTO_UI_PATH = "/ui";
   public static final String USER_HEADER = "X-Presto-User";
   public static final String SOURCE_HEADER = "X-Presto-Source";
@@ -78,7 +79,8 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     return path.startsWith(V1_STATEMENT_PATH)
         || path.startsWith(V1_QUERY_PATH)
         || path.startsWith(PRESTO_UI_PATH)
-        || path.startsWith(V1_INFO_PATH);
+        || path.startsWith(V1_INFO_PATH)
+        || path.startsWith(V1_CLUSTER_PATH);
   }
 
   public boolean isAuthEnabled() {


### PR DESCRIPTION
This PR whitelists the `v1/cluster` API so that redirects from the query to the presto cluster render with the right details. Since this is currently not whitelisted, the UI shows a bunch of `NaN`s like this:
![image](https://user-images.githubusercontent.com/37013543/73209538-6a7ec400-4116-11ea-8061-b380f51fefd1.png)

Issue to track this: https://github.com/lyft/presto-gateway/issues/88