### PR TITLE
Add ExternalUrl to Active Backends Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,26 @@ curl -X POST http://localhost:8080/entity?entityType=GATEWAY_BACKEND \
     }'
 
 ```
+If the backend URL is different from the `proxyTo` URL (for example if they are internal vs. external hostnames). You can use the optional `externalUrl` field to override the link in the Active Backends page.
+```$xslt
+curl -X POST http://localhost:8080/entity?entityType=GATEWAY_BACKEND \
+ -d '{  "name": "presto1", \ 
+        "proxyTo": "http://presto1.lyft.com",\
+        "active": true, \
+        "routingGroup": "adhoc" \
+        "externalUrl": "http://presto1-external.lyft.com",\
+    }'
+
+curl -X POST http://localhost:8080/entity?entityType=GATEWAY_BACKEND \
+ -d '{  "name": "presto2", \ 
+        "proxyTo": "http://presto2.lyft.com",\
+        "active": true, \
+        "routingGroup": "adhoc" \
+        "externalUrl": "http://presto2-external.lyft.com",\
+    }'
+
+```
+
 
 ### Get all backends behind the gateway
 ```$xslt

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -107,6 +107,7 @@ public class ActiveClusterMonitor implements Managed {
         clusterStats.setRunningQueryCount((int) result.get("runningQueries"));
         clusterStats.setBlockedQueryCount((int) result.get("blockedQueries"));
         clusterStats.setProxyTo(backend.getProxyTo());
+        clusterStats.setExternalUrl(backend.getExternalUrl());
         clusterStats.setRoutingGroup(backend.getRoutingGroup());
       } else {
         log.warn("Received non 200 response, response code: {}", responseCode);

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ClusterStats.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ClusterStats.java
@@ -13,5 +13,6 @@ public class ClusterStats {
   private boolean healthy;
   private String clusterId;
   private String proxyTo;
+  private String externalUrl;
   private String routingGroup;
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/ProxyBackendConfiguration.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/ProxyBackendConfiguration.java
@@ -11,12 +11,11 @@ import lombok.RequiredArgsConstructor;
 public class ProxyBackendConfiguration extends ProxyServerConfiguration {
   private boolean active = true;
   private String routingGroup = "adhoc";
-  private String proxyTo;
   private String externalUrl;
 
   public String getExternalUrl() {
     if (externalUrl == null) {
-      return proxyTo;
+      return getProxyTo();
     }
     return externalUrl;
   }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/ProxyBackendConfiguration.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/ProxyBackendConfiguration.java
@@ -11,4 +11,14 @@ import lombok.RequiredArgsConstructor;
 public class ProxyBackendConfiguration extends ProxyServerConfiguration {
   private boolean active = true;
   private String routingGroup = "adhoc";
+  private String proxyTo;
+  private String externalUrl;
+
+  public String getExternalUrl() {
+    if (externalUrl == null) {
+      return proxyTo;
+    }
+    return externalUrl;
+  }
+
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/GatewayBackend.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/GatewayBackend.java
@@ -17,6 +17,7 @@ public class GatewayBackend extends Model {
   private static final String name = "name";
   private static final String routingGroup = "routing_group";
   private static final String backendUrl = "backend_url";
+  private static final String externalUrl = "external_url";
   private static final String active = "active";
 
   public static List<ProxyBackendConfiguration> upcast(List<GatewayBackend> gatewayBackendList) {
@@ -26,6 +27,7 @@ public class GatewayBackend extends Model {
       backendConfig.setActive(model.getBoolean(active));
       backendConfig.setRoutingGroup(model.getString(routingGroup));
       backendConfig.setProxyTo(model.getString(backendUrl));
+      backendConfig.setExternalUrl(model.getString(externalUrl));
       backendConfig.setName(model.getString(name));
       proxyBackendConfigurations.add(backendConfig);
     }
@@ -37,6 +39,7 @@ public class GatewayBackend extends Model {
         .set(name, backend.getName())
         .set(routingGroup, backend.getRoutingGroup())
         .set(backendUrl, backend.getProxyTo())
+        .set(externalUrl, backend.getExternalUrl())
         .set(active, backend.isActive())
         .saveIt();
   }

--- a/gateway-ha/src/main/resources/gateway-ha-persistence.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS gateway_backend (
 name VARCHAR(256) PRIMARY KEY,
 routing_group VARCHAR (256),
 backend_url VARCHAR (256),
+external_url VARCHAR (256),
 active BOOLEAN
 );
 

--- a/gateway-ha/src/main/resources/template/gateway-view.ftl
+++ b/gateway-ha/src/main/resources/template/gateway-view.ftl
@@ -58,7 +58,7 @@
         <#list backendConfigurations as bc>
             <tr>
                 <td>  ${bc.name}</td>
-                <td><a href="${bc.proxyTo}/ui" target="_blank">${bc.proxyTo}</a></td>
+                <td><a href="${bc.externalUrl}/ui" target="_blank">${bc.externalUrl}</a></td>
                 <td> ${bc.routingGroup}</td>
             </tr>
         </#list>

--- a/gateway-ha/src/migrations/gateway-ha.sql
+++ b/gateway-ha/src/migrations/gateway-ha.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS gateway_backend (
 name VARCHAR(256) PRIMARY KEY,
 routing_group VARCHAR (256),
 backend_url VARCHAR (256),
+external_url VARCHAR (256),
 active BOOLEAN
 );
 

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/HaGatewayTestUtils.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/HaGatewayTestUtils.java
@@ -95,7 +95,12 @@ public class HaGatewayTestUtils {
   }
 
   public static void setUpBackend(
-      String name, String proxyTo, boolean active, String routingGroup, int routerPort)
+      String name,
+      String proxyTo,
+      String externalUrl,
+      boolean active,
+      String routingGroup,
+      int routerPort)
       throws Exception {
     RequestBody requestBody =
         RequestBody.create(
@@ -104,6 +109,8 @@ public class HaGatewayTestUtils {
                 + name
                 + "\",\"proxyTo\": \""
                 + proxyTo
+                + "\",\"externalUrl\": \""
+                + externalUrl
                 + "\",\"active\": "
                 + active
                 + ",\"routingGroup\": \""

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/TestGatewayHaMulipleBackend.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/TestGatewayHaMulipleBackend.java
@@ -39,9 +39,9 @@ public class TestGatewayHaMulipleBackend {
     HaGatewayLauncher.main(args);
     // Now populate the backend
     HaGatewayTestUtils.setUpBackend(
-        "presto1", "http://localhost:" + backend1Port, true, "adhoc", routerPort);
+        "presto1", "http://localhost:" + backend1Port, "externalUrl", true, "adhoc", routerPort);
     HaGatewayTestUtils.setUpBackend(
-        "presto2", "http://localhost:" + backend2Port, true, "scheduled", routerPort);
+        "presto2", "http://localhost:" + backend2Port, "externalUrl", true, "scheduled", routerPort);
   }
 
   @Test

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/TestGatewayHaSingleBackend.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/TestGatewayHaSingleBackend.java
@@ -33,7 +33,7 @@ public class TestGatewayHaSingleBackend {
     HaGatewayLauncher.main(args);
     // Now populate the backend
     HaGatewayTestUtils.setUpBackend(
-        "presto1", "http://localhost:" + backendPort, true, "adhoc", routerPort);
+        "presto1", "http://localhost:" + backendPort, "externalUrl", true, "adhoc", routerPort);
   }
 
   @Test

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestHaGatewayManager.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestHaGatewayManager.java
@@ -35,6 +35,7 @@ public class TestHaGatewayManager {
     backend.setRoutingGroup("adhoc");
     backend.setName("adhoc1");
     backend.setProxyTo("adhoc1.presto.lyft.com");
+    backend.setExternalUrl("adhoc1.presto.lyft.com");
     ProxyBackendConfiguration updated = haGatewayManager.addBackend(backend);
     Assert.assertEquals(updated, backend);
   }
@@ -61,6 +62,7 @@ public class TestHaGatewayManager {
     backend.setRoutingGroup("adhoc");
     backend.setName("adhoc-lyft-1");
     backend.setProxyTo("adhoc1.presto.lyft.com");
+    backend.setExternalUrl("adhoc1.presto.lyft.com");
     haGatewayManager.updateBackend(backend);
     List<ProxyBackendConfiguration> backends = haGatewayManager.getActiveBackends("adhoc");
     Assert.assertEquals(backends.size(), 1);
@@ -69,6 +71,7 @@ public class TestHaGatewayManager {
     backend.setRoutingGroup("etl");
     backend.setName("adhoc1");
     backend.setProxyTo("adhoc1.presto.lyft.com");
+    backend.setExternalUrl("adhoc1.presto.lyft.com");
     haGatewayManager.updateBackend(backend);
     backends = haGatewayManager.getActiveBackends("adhoc");
     Assert.assertEquals(backends.size(), 0);

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -65,6 +65,7 @@ public class TestPrestoQueueLengthRoutingTable {
       proxyBackend.setRoutingGroup(groupName);
       proxyBackend.setName(backend);
       proxyBackend.setProxyTo(backend + ".presto.lyft.com");
+      proxyBackend.setExternalUrl("presto.lyft.com");
       backendManager.addBackend(proxyBackend);
     }
   }

--- a/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServerConfiguration.java
+++ b/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServerConfiguration.java
@@ -7,12 +7,20 @@ public class ProxyServerConfiguration {
   private String name;
   private int localPort;
   private String proxyTo;
+  private String externalUrl;
   private String prefix = "/";
   private String trustAll = "true";
   private String preserveHost = "true";
   private boolean ssl;
   private String keystorePath;
   private String keystorePass;
+
+  public String getExternalUrl() {
+    if (externalUrl == null) {
+      return proxyTo;
+    }
+    return externalUrl;
+  }
 
   protected String getPrefix() {
     return prefix;

--- a/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServerConfiguration.java
+++ b/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServerConfiguration.java
@@ -7,20 +7,12 @@ public class ProxyServerConfiguration {
   private String name;
   private int localPort;
   private String proxyTo;
-  private String externalUrl;
   private String prefix = "/";
   private String trustAll = "true";
   private String preserveHost = "true";
   private boolean ssl;
   private String keystorePath;
   private String keystorePass;
-
-  public String getExternalUrl() {
-    if (externalUrl == null) {
-      return proxyTo;
-    }
-    return externalUrl;
-  }
 
   protected String getPrefix() {
     return prefix;


### PR DESCRIPTION
When running Presto Gateway on Kubernetes pods in Google Cloud Platform the backend URL uses an internal endpoint for requests. This works fine until a user tries to use the URL on the Active Backends page in the UI. This uses the internal hostname and therefore cannot be reached by users outside of the network. To work around this I'd like to add an optional `externalUrl` field that can be used to point to an external hostname. The field could be passed in like this:
```
curl -X POST http://localhost:8080/entity\?entityType\=GATEWAY_BACKEND \
-d '{"name":"presto1", \
     "proxyTo": "presto1.lyft.com", \
     "externalUrl": "http://my-external-url.com", \
     "active": true, \
     "routingGroup": "adhoc"}'


curl -X POST http://localhost:8080/entity\?entityType\=GATEWAY_BACKEND \
-d '{"name":"presto2", \
     "proxyTo": "presto2.lyft.com", \
     "active": true, \
     "routingGroup": "adhoc"}'
```
If the `externalUrl` field is passed in then it will appear in the Active Backends UI under the `URL` heading instead of the `proxyTo` value. If it is not passed in then the value passed into `proxyTo` will appear in it's place, just as normal.

Here is an example (on my local development) using the `externalUrl` field to override the `proxyTo` field in the Active Backends page using the requests from above:

<img width="971" alt="Screen Shot 2020-04-16 at 11 29 44 AM" src="https://user-images.githubusercontent.com/28543444/80360221-4a7ab000-887f-11ea-892d-b20e43bf2219.png">

I didn't see a reason to include both `proxyTo` and `externalUrl` if both are present, but if there is any reason they are both needed I can change it so that both are presented in the page.