### PR TITLE
Define RoutingGroupSelector interface for customizable routing

### DIFF
--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -113,6 +113,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>1.4.192</version>

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -33,7 +33,6 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
   public static final String PRESTO_UI_PATH = "/ui";
   public static final String USER_HEADER = "X-Presto-User";
   public static final String SOURCE_HEADER = "X-Presto-Source";
-  public static final String ROUTING_GROUP_HEADER = "X-Presto-Routing-Group";
   private static final int QUERY_TEXT_LENGTH_FOR_HISTORY = 200;
   private static final Pattern QUERY_ID_PATTERN = Pattern.compile(".*[/=](\\d+_\\d+_\\d+_\\w+).*");
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
@@ -13,6 +13,7 @@ import com.lyft.data.gateway.ha.router.HaGatewayManager;
 import com.lyft.data.gateway.ha.router.HaQueryHistoryManager;
 import com.lyft.data.gateway.ha.router.HaRoutingManager;
 import com.lyft.data.gateway.ha.router.QueryHistoryManager;
+import com.lyft.data.gateway.ha.router.RoutingGroupSelector;
 import com.lyft.data.gateway.ha.router.RoutingManager;
 import com.lyft.data.proxyserver.ProxyHandler;
 import com.lyft.data.proxyserver.ProxyServer;
@@ -41,7 +42,11 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
             .metrics()
             .meter(getConfiguration().getRequestRouter().getName() + ".requests");
     return new QueryIdCachingProxyHandler(
-        getQueryHistoryManager(), getRoutingManager(), getApplicationPort(), requestMeter);
+        getQueryHistoryManager(),
+        getRoutingManager(),
+        RoutingGroupSelector.byRoutingGroupHeader(),
+        getApplicationPort(),
+        requestMeter);
   }
 
   @Provides
@@ -89,5 +94,4 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
   public JdbcConnectionManager getConnectionManager() {
     return this.connectionManager;
   }
-
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
@@ -1,0 +1,20 @@
+package com.lyft.data.gateway.ha.router;
+
+import javax.servlet.http.HttpServletRequest;
+
+/** RoutingGroupSelector provides a way to match an HTTP request to a Gateway routing group. */
+public interface RoutingGroupSelector {
+  /**
+   * Routing group selector that relies on the X-Presto-Routing-Group header to determine the right
+   * routing group.
+   */
+  static RoutingGroupSelector byRoutingGroupHeader() {
+    return request -> request.getHeader("X-Presto-Routing-Group");
+  }
+
+  /**
+   * Given an HTTP request find a routing group to direct the request to. If a routing group cannot
+   * be determined return null.
+   */
+  String findRoutingGroup(HttpServletRequest request);
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
@@ -4,12 +4,14 @@ import javax.servlet.http.HttpServletRequest;
 
 /** RoutingGroupSelector provides a way to match an HTTP request to a Gateway routing group. */
 public interface RoutingGroupSelector {
+  String ROUTING_GROUP_HEADER = "X-Presto-Routing-Group";
+
   /**
    * Routing group selector that relies on the X-Presto-Routing-Group header to determine the right
    * routing group.
    */
   static RoutingGroupSelector byRoutingGroupHeader() {
-    return request -> request.getHeader("X-Presto-Routing-Group");
+    return request -> request.getHeader(ROUTING_GROUP_HEADER);
   }
 
   /**

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
@@ -1,5 +1,6 @@
 package com.lyft.data.gateway.ha.router;
 
+import static com.lyft.data.gateway.ha.router.RoutingGroupSelector.ROUTING_GROUP_HEADER;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -13,12 +14,12 @@ public class TestRoutingGroupSelector {
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
 
     // If the header is present the routing group is the value of that header.
-    when(mockRequest.getHeader("X-Presto-Routing-Group")).thenReturn("batch_backend");
+    when(mockRequest.getHeader(ROUTING_GROUP_HEADER)).thenReturn("batch_backend");
     Assert.assertEquals(
         RoutingGroupSelector.byRoutingGroupHeader().findRoutingGroup(mockRequest), "batch_backend");
 
     // If the header is not present just return null.
-    when(mockRequest.getHeader("X-Presto-Routing-Group")).thenReturn(null);
+    when(mockRequest.getHeader(ROUTING_GROUP_HEADER)).thenReturn(null);
     Assert.assertNull(RoutingGroupSelector.byRoutingGroupHeader().findRoutingGroup(mockRequest));
   }
 }

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
@@ -1,0 +1,24 @@
+package com.lyft.data.gateway.ha.router;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test
+public class TestRoutingGroupSelector {
+  public void testByRoutingGroupHeader() {
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+
+    // If the header is present the routing group is the value of that header.
+    when(mockRequest.getHeader("X-Presto-Routing-Group")).thenReturn("batch_backend");
+    Assert.assertEquals(
+        RoutingGroupSelector.byRoutingGroupHeader().findRoutingGroup(mockRequest), "batch_backend");
+
+    // If the header is not present just return null.
+    when(mockRequest.getHeader("X-Presto-Routing-Group")).thenReturn(null);
+    Assert.assertNull(RoutingGroupSelector.byRoutingGroupHeader().findRoutingGroup(mockRequest));
+  }
+}


### PR DESCRIPTION
## Summary

Define the `RoutingGroupSelector` interface as an abstraction to allow for custom routing group selectors in the future.

Currently it keeps the same behavior by using a selector that is based on the `X-Presto-Routing-Group` header. This is the first step towards https://github.com/lyft/presto-gateway/issues/62
