### PR TITLE
Merging Resource Group Management code into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,130 @@ PrestoGateway records history of recent queries and displays links to check quer
 The Gateway admin page is used to configure the gateway to multiple backends. Existing backend information can also be modified using the same.
 ![prestogateway.lyft.com/entity](/docs/assets/prestogateway_ha_admin.png)
 
+## Resource Groups API
+
+### Add a resource group
+To add a single resource group, specify all relevant fields in the body.
+```$xslt
+curl -X POST http://localhost:8080/presto/resourcegroup/create \
+ -d '{  "resourceGroupId": 1, \
+        "name": "resourcegroup1", \
+        "softMemoryLimit": "100%", \
+        "maxQueued": 100, \
+        "softConcurrencyLimit": 100, \
+        "hardConcurrencyLimit": 100, \
+        "environment": "test", \
+        "schedulingPolicy": null, \
+        "schedulingWeight": null, \
+        "jmxExport": null, \
+        "softCpuLimit": null, \
+        "hardCpuLimit": null, \
+        "parent": null, \
+        "environment": "test" \
+    }'
+```
+
+### Get existing resource group(s)
+If no resourceGroupId (type long) is specified, then all existing resource groups are fetched. 
+```$xslt
+curl -X GET http://localhost:8080/presto/resourcegroup/read/{INSERT_ID_HERE}
+```
+
+### Update a resource group
+Specify all columns in the body, which will overwrite properties for the resource group with that specific resourceGroupId.
+```$xslt
+curl -X POST http://localhost:8080/presto/resourcegroup/update \
+ -d '{  "resourceGroupId": 1, \
+        "name": "resourcegroup_updated", \
+        "softMemoryLimit": "80%", \
+        "maxQueued": 50, \
+        "softConcurrencyLimit": 40, \
+        "hardConcurrencyLimit": 60, \
+        "environment": "test", \
+        "schedulingPolicy": null, \
+        "schedulingWeight": null, \
+        "jmxExport": null, \
+        "softCpuLimit": null, \
+        "hardCpuLimit": null, \
+        "parent": null, \
+        "environment": "test" \
+    }'
+```
+
+### Delete a resource group
+To delete a resource group, specify the corresponding resourceGroupId (type long).
+```$xslt
+curl -X POST http://localhost:8080/presto/resourcegroup/delete/{INSERT_ID_HERE}
+```
+
+### Add a selector
+To add a single selector, specify all relevant fields in the body.
+```$xslt
+curl -X POST http://localhost:8080/presto/selector/create \
+ -d '{  "resourceGroupId": 1, \
+        "priority": 1, \
+        "userRegex": "selector1", \
+        "sourceRegex": "resourcegroup1", \
+        "queryType": "insert" \
+     }'
+```
+
+### Get existing selectors(s)
+If no resourceGroupId (type long) is specified, then all existing selectors are fetched. 
+```$xslt
+curl -X GET http://localhost:8080/presto/selector/read/{INSERT_ID_HERE}
+```
+
+### Update a selector
+Specify all columns in the body, which will overwrite properties for the selector with that specific resourceGroupId.
+```$xslt
+curl -X POST http://localhost:8080/presto/selector/update \
+ -d '{  "resourceGroupId": 1, \
+        "priority": 2, \
+        "userRegex": "selector_updated", \
+        "sourceRegex": "resourcegroup1", \
+        "queryType": "insert" \
+     }'
+```
+
+### Delete a selector
+To delete a selector, specify the corresponding resourceGroupId (type long).
+```$xslt
+curl -X POST http://localhost:8080/presto/selector/delete/{INSERT_ID_HERE}
+```
+
+### Add a global property
+To add a single global property, specify all relevant fields in the body.
+```$xslt
+curl -X POST http://localhost:8080/presto/globalproperty/create \
+ -d '{
+        "name": "cpu_quota_period", \
+        "value": "1h" \
+     }'
+```
+
+### Get existing global properties
+If no name (type String) is specified, then all existing global properties are fetched. 
+```$xslt
+curl -X GET http://localhost:8080/presto/globalproperty/read/{INSERT_NAME_HERE}
+```
+
+### Update a global property
+Specify all columns in the body, which will overwrite properties for the global property with that specific name.
+```$xslt
+curl -X POST http://localhost:8080/presto/globalproperty/update \
+ -d '{
+        "name": "cpu_quota_period", \
+        "value": "2h" \
+     }'
+```
+
+### Delete a global property
+To delete a global property, specify the corresponding name (type String).
+```$xslt
+curl -X POST http://localhost:8080/presto/globalproperty/delete/{INSERT_NAME_HERE}
+```
+
 ## Contributing
 
 Want to help build Presto Gateway? Check out our [contributing documentation](CONTRIBUTING.md)

--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
@@ -11,8 +11,10 @@ import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
 import com.lyft.data.gateway.ha.router.GatewayBackendManager;
 import com.lyft.data.gateway.ha.router.HaGatewayManager;
 import com.lyft.data.gateway.ha.router.HaQueryHistoryManager;
+import com.lyft.data.gateway.ha.router.HaResourceGroupsManager;
 import com.lyft.data.gateway.ha.router.HaRoutingManager;
 import com.lyft.data.gateway.ha.router.QueryHistoryManager;
+import com.lyft.data.gateway.ha.router.ResourceGroupsManager;
 import com.lyft.data.gateway.ha.router.RoutingGroupSelector;
 import com.lyft.data.gateway.ha.router.RoutingManager;
 import com.lyft.data.proxyserver.ProxyHandler;
@@ -22,6 +24,7 @@ import io.dropwizard.setup.Environment;
 
 public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, Environment> {
 
+  private final ResourceGroupsManager resourceGroupsManager;
   private final GatewayBackendManager gatewayBackendManager;
   private final QueryHistoryManager queryHistoryManager;
   private final RoutingManager routingManager;
@@ -30,6 +33,7 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
   public HaGatewayProviderModule(HaGatewayConfiguration configuration, Environment environment) {
     super(configuration, environment);
     connectionManager = new JdbcConnectionManager(configuration.getDataStore());
+    resourceGroupsManager = new HaResourceGroupsManager(connectionManager);
     gatewayBackendManager = new HaGatewayManager(connectionManager);
     queryHistoryManager = new HaQueryHistoryManager(connectionManager);
     routingManager =
@@ -69,6 +73,12 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
       gateway = new ProxyServer(routerProxyConfig, proxyHandler);
     }
     return gateway;
+  }
+
+  @Provides
+  @Singleton
+  public ResourceGroupsManager getPrestoResourceManager() {
+    return this.resourceGroupsManager;
   }
 
   @Provides

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/ExactMatchSourceSelectors.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/ExactMatchSourceSelectors.java
@@ -1,0 +1,83 @@
+package com.lyft.data.gateway.ha.persistence.dao;
+
+import static com.lyft.data.gateway.ha.router.ResourceGroupsManager.ExactSelectorsDetail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.javalite.activejdbc.Model;
+import org.javalite.activejdbc.annotations.Cached;
+import org.javalite.activejdbc.annotations.CompositePK;
+import org.javalite.activejdbc.annotations.Table;
+
+@CompositePK({"environment", "source", "query_type"})
+@Table("exact_match_source_selectors") // located in gateway-ha-persistence.sql
+@Cached
+public class ExactMatchSourceSelectors extends Model {
+  private static final String resourceGroupId = "resource_group_id";
+  private static final String updateTime = "update_time";
+
+  private static final String source = "source";
+  private static final String environment = "environment";
+  private static final String queryType = "query_type";
+
+  /**
+   * Returns the most specific exact-match selector for a given environment, source and query type.
+   * NULL values in the environment and query type fields signify wildcards.
+   *
+   * @param exactMatchSourceSelectorsList
+   * @return List of ExactMatchSourceSelectors
+   */
+  public static List<ExactSelectorsDetail> upcast(
+      List<ExactMatchSourceSelectors> exactMatchSourceSelectorsList) {
+    List<ExactSelectorsDetail> exactSelectors = new ArrayList<>();
+    for (ExactMatchSourceSelectors dao : exactMatchSourceSelectorsList) {
+      ExactSelectorsDetail exactSelectorDetail = new ExactSelectorsDetail();
+      exactSelectorDetail.setResourceGroupId(dao.getString(resourceGroupId));
+      exactSelectorDetail.setUpdateTime(dao.getString(updateTime));
+
+      exactSelectorDetail.setSource(dao.getString(source));
+      exactSelectorDetail.setEnvironment(dao.getString(environment));
+      exactSelectorDetail.setQueryType(dao.getString(queryType));
+
+      exactSelectors.add(exactSelectorDetail);
+    }
+    return exactSelectors;
+  }
+
+  /**
+   * Create a new exactMatchSourceSelector.
+   *
+   * @param model
+   * @param exactSelectorsDetail
+   */
+  public static void create(
+      ExactMatchSourceSelectors model, ExactSelectorsDetail exactSelectorsDetail) {
+    model.set(resourceGroupId, exactSelectorsDetail.getResourceGroupId());
+    model.set(updateTime, exactSelectorsDetail.getUpdateTime());
+
+    model.set(source, exactSelectorsDetail.getSource());
+    model.set(environment, exactSelectorsDetail.getEnvironment());
+    model.set(queryType, exactSelectorsDetail.getQueryType());
+
+    model.insert();
+  }
+
+  /**
+   * Update existing exactMatchSourceSelector.
+   *
+   * @param model
+   * @param exactSelectorsDetail
+   */
+  public static void update(
+      ExactMatchSourceSelectors model, ExactSelectorsDetail exactSelectorsDetail) {
+    model.set(resourceGroupId, exactSelectorsDetail.getResourceGroupId());
+    model.set(updateTime, exactSelectorsDetail.getUpdateTime());
+
+    model.set(source, exactSelectorsDetail.getSource());
+    model.set(environment, exactSelectorsDetail.getEnvironment());
+    model.set(queryType, exactSelectorsDetail.getQueryType());
+
+    model.saveIt();
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/ResourceGroups.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/ResourceGroups.java
@@ -1,0 +1,121 @@
+package com.lyft.data.gateway.ha.persistence.dao;
+
+import static com.lyft.data.gateway.ha.router.ResourceGroupsManager.ResourceGroupsDetail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.javalite.activejdbc.Model;
+import org.javalite.activejdbc.annotations.BelongsTo;
+import org.javalite.activejdbc.annotations.Cached;
+import org.javalite.activejdbc.annotations.IdName;
+import org.javalite.activejdbc.annotations.Table;
+
+@BelongsTo(parent = ResourceGroups.class, foreignKeyName = "parent")
+@IdName("resource_group_id")
+@Table("resource_groups") // located in gateway-ha-persistence.sql
+@Cached
+public class ResourceGroups extends Model {
+  private static final String resourceGroupId = "resource_group_id";
+  private static final String name = "name";
+
+  /* OPTIONAL POLICY CONTROLS */
+  private static final String parent = "parent";
+  private static final String jmxExport = "jmx_export";
+  private static final String schedulingPolicy = "scheduling_policy";
+  private static final String schedulingWeight = "scheduling_weight";
+
+  /* REQUIRED QUOTAS */
+  private static final String softMemoryLimit = "soft_memory_limit";
+  private static final String maxQueued = "max_queued";
+  private static final String hardConcurrencyLimit = "hard_concurrency_limit";
+
+  /* OPTIONAL QUOTAS */
+  private static final String softConcurrencyLimit = "soft_concurrency_limit";
+  private static final String softCpuLimit = "soft_cpu_limit";
+  private static final String hardCpuLimit = "hard_cpu_limit";
+  private static final String environment = "environment";
+
+  /**
+   * Reads all existing resource groups and returns them in a list.
+   *
+   * @param resourceGroupList
+   * @return List of ResourceGroupDetail objects
+   */
+  public static List<ResourceGroupsDetail> upcast(List<ResourceGroups> resourceGroupList) {
+    List<ResourceGroupsDetail> resourceGroupDetails = new ArrayList<>();
+    for (ResourceGroups dao : resourceGroupList) {
+      ResourceGroupsDetail resourceGroupDetail = new ResourceGroupsDetail();
+      resourceGroupDetail.setResourceGroupId(dao.getLong(resourceGroupId));
+      resourceGroupDetail.setName(dao.getString(name));
+
+      resourceGroupDetail.setParent(dao.getLong(parent));
+      resourceGroupDetail.setJmxExport(dao.getBoolean(jmxExport));
+      resourceGroupDetail.setSchedulingPolicy(dao.getString(schedulingPolicy));
+      resourceGroupDetail.setSchedulingWeight(dao.getInteger(schedulingWeight));
+
+      resourceGroupDetail.setSoftMemoryLimit(dao.getString(softMemoryLimit));
+      resourceGroupDetail.setMaxQueued(dao.getInteger(maxQueued));
+      resourceGroupDetail.setHardConcurrencyLimit(dao.getInteger(hardConcurrencyLimit));
+
+      resourceGroupDetail.setSoftConcurrencyLimit(dao.getInteger(softConcurrencyLimit));
+      resourceGroupDetail.setSoftCpuLimit(dao.getString(softCpuLimit));
+      resourceGroupDetail.setHardCpuLimit(dao.getString(hardCpuLimit));
+      resourceGroupDetail.setEnvironment(dao.getString(environment));
+
+      resourceGroupDetails.add(resourceGroupDetail);
+    }
+    return resourceGroupDetails;
+  }
+
+  /**
+   * Creates a new ResourceGroup model.
+   *
+   * @param model
+   * @param resourceGroupDetail
+   */
+  public static void create(ResourceGroups model, ResourceGroupsDetail resourceGroupDetail) {
+    model.set(resourceGroupId, resourceGroupDetail.getResourceGroupId());
+    model.set(name, resourceGroupDetail.getName());
+
+    model.set(parent, resourceGroupDetail.getParent());
+    model.set(jmxExport, resourceGroupDetail.isJmxExport());
+    model.set(schedulingPolicy, resourceGroupDetail.getSchedulingPolicy());
+    model.set(schedulingWeight, resourceGroupDetail.getSchedulingWeight());
+
+    model.set(softMemoryLimit, resourceGroupDetail.getSoftMemoryLimit());
+    model.set(maxQueued, resourceGroupDetail.getMaxQueued());
+    model.set(hardConcurrencyLimit, resourceGroupDetail.getHardConcurrencyLimit());
+
+    model.set(softConcurrencyLimit, resourceGroupDetail.getSoftConcurrencyLimit());
+    model.set(softCpuLimit, resourceGroupDetail.getSoftCpuLimit());
+    model.set(hardCpuLimit, resourceGroupDetail.getHardCpuLimit());
+    model.set(environment, resourceGroupDetail.getEnvironment());
+
+    model.insert();
+  }
+
+  /**
+   * Updates and saves an existing ResourceGroup model.
+   *
+   * @param model
+   * @param resourceGroupDetail
+   */
+  public static void update(ResourceGroups model, ResourceGroupsDetail resourceGroupDetail) {
+    model
+        .set(resourceGroupId, resourceGroupDetail.getResourceGroupId())
+        .set(name, resourceGroupDetail.getName())
+        .set(parent, resourceGroupDetail.getParent())
+        .set(jmxExport, resourceGroupDetail.isJmxExport())
+        .set(schedulingPolicy, resourceGroupDetail.getSchedulingPolicy())
+        .set(schedulingWeight, resourceGroupDetail.getSchedulingWeight())
+        .set(softMemoryLimit, resourceGroupDetail.getSoftMemoryLimit())
+        .set(maxQueued, resourceGroupDetail.getMaxQueued())
+        .set(hardConcurrencyLimit, resourceGroupDetail.getHardConcurrencyLimit())
+        .set(softConcurrencyLimit, resourceGroupDetail.getSoftConcurrencyLimit())
+        .set(softCpuLimit, resourceGroupDetail.getSoftCpuLimit())
+        .set(hardCpuLimit, resourceGroupDetail.getHardCpuLimit())
+        .set(environment, resourceGroupDetail.getEnvironment())
+        .saveIt();
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/ResourceGroups.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/ResourceGroups.java
@@ -8,10 +8,12 @@ import java.util.List;
 import org.javalite.activejdbc.Model;
 import org.javalite.activejdbc.annotations.BelongsTo;
 import org.javalite.activejdbc.annotations.Cached;
+import org.javalite.activejdbc.annotations.HasMany;
 import org.javalite.activejdbc.annotations.IdName;
 import org.javalite.activejdbc.annotations.Table;
 
 @BelongsTo(parent = ResourceGroups.class, foreignKeyName = "parent")
+@HasMany(child = ResourceGroups.class, foreignKeyName = "parent")
 @IdName("resource_group_id")
 @Table("resource_groups") // located in gateway-ha-persistence.sql
 @Cached
@@ -79,7 +81,7 @@ public class ResourceGroups extends Model {
     model.set(name, resourceGroupDetail.getName());
 
     model.set(parent, resourceGroupDetail.getParent());
-    model.set(jmxExport, resourceGroupDetail.isJmxExport());
+    model.set(jmxExport, resourceGroupDetail.getJmxExport());
     model.set(schedulingPolicy, resourceGroupDetail.getSchedulingPolicy());
     model.set(schedulingWeight, resourceGroupDetail.getSchedulingWeight());
 
@@ -106,7 +108,7 @@ public class ResourceGroups extends Model {
         .set(resourceGroupId, resourceGroupDetail.getResourceGroupId())
         .set(name, resourceGroupDetail.getName())
         .set(parent, resourceGroupDetail.getParent())
-        .set(jmxExport, resourceGroupDetail.isJmxExport())
+        .set(jmxExport, resourceGroupDetail.getJmxExport())
         .set(schedulingPolicy, resourceGroupDetail.getSchedulingPolicy())
         .set(schedulingWeight, resourceGroupDetail.getSchedulingWeight())
         .set(softMemoryLimit, resourceGroupDetail.getSoftMemoryLimit())

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/ResourceGroupsGlobalProperties.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/ResourceGroupsGlobalProperties.java
@@ -1,0 +1,66 @@
+package com.lyft.data.gateway.ha.persistence.dao;
+
+import static com.lyft.data.gateway.ha.router.ResourceGroupsManager.GlobalPropertiesDetail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.javalite.activejdbc.Model;
+import org.javalite.activejdbc.annotations.Cached;
+import org.javalite.activejdbc.annotations.IdName;
+import org.javalite.activejdbc.annotations.Table;
+
+@IdName("name")
+@Table("resource_groups_global_properties") // located in gateway-ha-persistence.sql
+@Cached
+public class ResourceGroupsGlobalProperties extends Model {
+  private static final String name = "name";
+  private static final String value = "value";
+
+  /**
+   * Reads all existing global properties and returns them in a List.
+   *
+   * @param globalPropertiesList
+   * @return List of ResourceGroupGlobalProperties
+   */
+  public static List<GlobalPropertiesDetail> upcast(
+      List<ResourceGroupsGlobalProperties> globalPropertiesList) {
+    List<GlobalPropertiesDetail> globalProperties = new ArrayList<>();
+    for (ResourceGroupsGlobalProperties dao : globalPropertiesList) {
+      GlobalPropertiesDetail globalPropertiesDetail = new GlobalPropertiesDetail();
+      globalPropertiesDetail.setName(dao.getString(name));
+      globalPropertiesDetail.setValue(dao.getString(value));
+
+      globalProperties.add(globalPropertiesDetail);
+    }
+    return globalProperties;
+  }
+
+  /**
+   * Creates a new global property.
+   *
+   * @param model
+   * @param globalPropertiesDetail
+   */
+  public static void create(
+      ResourceGroupsGlobalProperties model, GlobalPropertiesDetail globalPropertiesDetail) {
+    model.set(name, globalPropertiesDetail.getName());
+    model.set(value, globalPropertiesDetail.getValue());
+
+    model.insert();
+  }
+
+  /**
+   * Updates existing global property.
+   *
+   * @param model
+   * @param globalPropertiesDetail
+   */
+  public static void update(
+      ResourceGroupsGlobalProperties model, GlobalPropertiesDetail globalPropertiesDetail) {
+    model.set(name, globalPropertiesDetail.getName());
+    model.set(value, globalPropertiesDetail.getValue());
+
+    model.saveIt();
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/Selectors.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/persistence/dao/Selectors.java
@@ -1,0 +1,86 @@
+package com.lyft.data.gateway.ha.persistence.dao;
+
+import static com.lyft.data.gateway.ha.router.ResourceGroupsManager.SelectorsDetail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.javalite.activejdbc.Model;
+import org.javalite.activejdbc.annotations.BelongsTo;
+import org.javalite.activejdbc.annotations.Cached;
+import org.javalite.activejdbc.annotations.IdName;
+import org.javalite.activejdbc.annotations.Table;
+
+@BelongsTo(parent = ResourceGroups.class, foreignKeyName = "resource_group_id")
+@IdName("resource_group_id")
+@Table("selectors") // located in gateway-ha-persistence.sql
+@Cached
+public class Selectors extends Model {
+  private static final String resourceGroupId = "resource_group_id";
+  private static final String priority = "priority";
+
+  private static final String userRegex = "user_regex";
+  private static final String sourceRegex = "source_regex";
+
+  private static final String queryType = "query_type";
+  private static final String clientTags = "client_tags";
+  private static final String selectorResourceEstimate = "selector_resource_estimate";
+
+  /**
+   * Retrieves all existing selectors and returns them in a List.
+   *
+   * @param selectorList
+   * @return a list of all existing selectors
+   */
+  public static List<SelectorsDetail> upcast(List<Selectors> selectorList) {
+    List<SelectorsDetail> selectorDetails = new ArrayList<>();
+    for (Selectors dao : selectorList) {
+      SelectorsDetail selectorDetail = new SelectorsDetail();
+      selectorDetail.setResourceGroupId(dao.getLong(resourceGroupId));
+      selectorDetail.setPriority(dao.getLong(priority));
+      selectorDetail.setUserRegex(dao.getString(userRegex));
+      selectorDetail.setSourceRegex(dao.getString(sourceRegex));
+      selectorDetail.setQueryType(dao.getString(queryType));
+      selectorDetail.setClientTags(dao.getString(clientTags));
+      selectorDetail.setSelectorResourceEstimate(dao.getString(selectorResourceEstimate));
+      selectorDetails.add(selectorDetail);
+    }
+    return selectorDetails;
+  }
+
+  /**
+   * Create a new Selector model with the given selector details.
+   *
+   * @param model
+   * @param selectorDetail
+   */
+  public static void create(Selectors model, SelectorsDetail selectorDetail) {
+    model.set(resourceGroupId, selectorDetail.getResourceGroupId());
+    model.set(priority, selectorDetail.getPriority());
+    model.set(userRegex, selectorDetail.getUserRegex());
+    model.set(sourceRegex, selectorDetail.getSourceRegex());
+    model.set(queryType, selectorDetail.getQueryType());
+    model.set(clientTags, selectorDetail.getClientTags());
+    model.set(selectorResourceEstimate, selectorDetail.getSelectorResourceEstimate());
+
+    model.insert();
+  }
+
+  /**
+   * Update an existing Selector model with the given selector details.
+   *
+   * @param model
+   * @param selectorDetail
+   */
+  public static void update(Selectors model, SelectorsDetail selectorDetail) {
+    model.set(resourceGroupId, selectorDetail.getResourceGroupId());
+    model.set(priority, selectorDetail.getPriority());
+    model.set(userRegex, selectorDetail.getUserRegex());
+    model.set(sourceRegex, selectorDetail.getSourceRegex());
+    model.set(queryType, selectorDetail.getQueryType());
+    model.set(clientTags, selectorDetail.getClientTags());
+    model.set(selectorResourceEstimate, selectorDetail.getSelectorResourceEstimate());
+
+    model.saveIt();
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/PrestoResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/PrestoResource.java
@@ -1,18 +1,23 @@
 package com.lyft.data.gateway.ha.resource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.google.inject.Inject;
-import com.lyft.data.gateway.ha.persistence.dao.ResourceGroups;
+
 import com.lyft.data.gateway.ha.router.ResourceGroupsManager;
+import com.lyft.data.gateway.ha.router.ResourceGroupsManager.ExactSelectorsDetail;
+import com.lyft.data.gateway.ha.router.ResourceGroupsManager.GlobalPropertiesDetail;
 import com.lyft.data.gateway.ha.router.ResourceGroupsManager.ResourceGroupsDetail;
 import com.lyft.data.gateway.ha.router.ResourceGroupsManager.SelectorsDetail;
 
 import java.io.IOException;
-import javax.ws.rs.Consumes;
+import java.util.List;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -22,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Path("/presto")
 @Produces(MediaType.APPLICATION_JSON)
-// @Consumes(MediaType.APPLICATION_JSON)
 public class PrestoResource {
   @Inject private ResourceGroupsManager resourceGroupsManager;
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -33,9 +37,9 @@ public class PrestoResource {
     try {
       ResourceGroupsDetail resourceGroup =
           OBJECT_MAPPER.readValue(jsonPayload, ResourceGroupsDetail.class);
-      ResourceGroupsDetail updatedResourceGroup =
+      ResourceGroupsDetail newResourceGroup =
           this.resourceGroupsManager.createResourceGroup(resourceGroup);
-      return Response.ok(updatedResourceGroup).build();
+      return Response.ok(newResourceGroup).build();
     } catch (IOException e) {
       log.error(e.getMessage(), e);
       throw new WebApplicationException(e);
@@ -44,55 +48,177 @@ public class PrestoResource {
 
   @GET
   @Path("/resourcegroup/read")
-  public Response readResourceGroup() {
-    return Response.ok(this.resourceGroupsManager.readResourceGroup()).build();
+  public Response readAllResourceGroups() {
+    return Response.ok(this.resourceGroupsManager.readAllResourceGroups()).build();
+  }
+
+  @GET
+  @Path("/resourcegroup/read/{resourceGroupId}")
+  public Response readResourceGroup(@PathParam("resourceGroupId") String resourceGroupIdStr) {
+    if (Strings.isNullOrEmpty(resourceGroupIdStr)) { // if query not specified, return all
+      return Response.ok(this.resourceGroupsManager.readAllResourceGroups()).build();
+    }
+    long resourceGroupId = Long.parseLong(resourceGroupIdStr);
+    List<ResourceGroupsDetail> resourceGroup =
+        this.resourceGroupsManager.readResourceGroup(resourceGroupId);
+    return Response.ok(resourceGroup).build();
   }
 
   @Path("/resourcegroup/update")
   @POST
-  public Response updateResourceGroup(ResourceGroupsDetail resourceGroup) {
-    ResourceGroupsDetail updatedResourceGroup =
-        this.resourceGroupsManager.updateResourceGroup(resourceGroup);
-    return Response.ok(updatedResourceGroup).build();
+  public Response updateResourceGroup(String jsonPayload) {
+    try {
+      ResourceGroupsDetail resourceGroup =
+          OBJECT_MAPPER.readValue(jsonPayload, ResourceGroupsDetail.class);
+      ResourceGroupsDetail updatedResourceGroup =
+          this.resourceGroupsManager.updateResourceGroup(resourceGroup);
+      return Response.ok(updatedResourceGroup).build();
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+      throw new WebApplicationException(e);
+    }
   }
 
-  @Path("/resourcegroup/delete")
+  @Path("/resourcegroup/delete/{resourceGroupId}")
   @POST
-  public Response deleteResourceGroup(long resourceGroupId) {
+  public Response deleteResourceGroup(@PathParam("resourceGroupId") String resourceGroupIdStr) {
+    if (Strings.isNullOrEmpty(resourceGroupIdStr)) { // if query not specified, return all
+      throw new WebApplicationException("EntryType can not be null");
+    }
+    long resourceGroupId = Long.parseLong(resourceGroupIdStr);
     resourceGroupsManager.deleteResourceGroup(resourceGroupId);
     return Response.ok().build();
   }
-  //
-  //  @POST
-  //  @Path("/selector/create")
-  //  public Response createSelector(String jsonPayload) {
-  //    try {
-  //      SelectorsDetail selector = OBJECT_MAPPER.readValue(jsonPayload, SelectorsDetail.class);
-  //      SelectorsDetail updatedSelector = this.resourceGroupsManager.createSelector(selector);
-  //      return Response.ok(updatedSelector).build();
-  //    } catch (IOException e) {
-  //      log.error(e.getMessage(), e);
-  //      throw new WebApplicationException(e);
-  //    }
-  //  }
-  //
-  //  @GET
-  //  @Path("/selector/read")
-  //  public Response readSelector() {
-  //    return Response.ok(this.resourceGroupsManager.readSelector()).build();
-  //  }
 
-  //  @Path("/selector/update")
-  //  @POST
-  //  public Response updateSelector(SelectorsDetail selector) {
-  //    SelectorsDetail updatedSelector = this.resourceGroupsManager.updateSelector(selector);
-  //    return Response.ok(updatedSelector).build();
-  //  }
-  //
-  //  @Path("/selector/delete")
-  //  @POST
-  //  public Response deleteSelector(long resourceGroupId) {
-  //    resourceGroupsManager.deleteSelector(resourceGroupId);
-  //    return Response.ok().build();
-  //  }
+  @POST
+  @Path("/selector/create")
+  public Response createSelector(String jsonPayload) {
+    try {
+      SelectorsDetail selector = OBJECT_MAPPER.readValue(jsonPayload, SelectorsDetail.class);
+      SelectorsDetail updatedSelector = this.resourceGroupsManager.createSelector(selector);
+      return Response.ok(updatedSelector).build();
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+      throw new WebApplicationException(e);
+    }
+  }
+
+  @GET
+  @Path("/selector/read")
+  public Response readAllSelectors() {
+    return Response.ok(this.resourceGroupsManager.readAllSelectors()).build();
+  }
+
+  @GET
+  @Path("/selector/read/{resourceGroupId}")
+  public Response readSelector(@QueryParam("resourceGroupId") String resourceGroupIdStr) {
+    if (Strings.isNullOrEmpty(resourceGroupIdStr)) { // if query not specified, return all
+      return Response.ok(this.resourceGroupsManager.readAllSelectors()).build();
+    }
+    long resourceGroupId = Long.parseLong(resourceGroupIdStr);
+    List<SelectorsDetail> selectors = this.resourceGroupsManager.readSelector(resourceGroupId);
+    return Response.ok(selectors).build();
+  }
+
+  @Path("/selector/update")
+  @POST
+  public Response updateSelector(String jsonPayload) {
+    try {
+      SelectorsDetail selector = OBJECT_MAPPER.readValue(jsonPayload, SelectorsDetail.class);
+      SelectorsDetail updatedSelector = this.resourceGroupsManager.updateSelector(selector);
+      return Response.ok(updatedSelector).build();
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+      throw new WebApplicationException(e);
+    }
+  }
+
+  @Path("/selector/delete/{resourceGroupId}")
+  @POST
+  public Response deleteSelector(@PathParam("resourceGroupId") String resourceGroupIdStr) {
+    if (Strings.isNullOrEmpty(resourceGroupIdStr)) { // if query not specified, return all
+      throw new WebApplicationException("EntryType can not be null");
+    }
+    long resourceGroupId = Long.parseLong(resourceGroupIdStr);
+    resourceGroupsManager.deleteSelector(resourceGroupId);
+    return Response.ok().build();
+  }
+
+  @POST
+  @Path("/globalproperty/create")
+  public Response createGlobalProperty(String jsonPayload) {
+    try {
+      GlobalPropertiesDetail globalProperty =
+          OBJECT_MAPPER.readValue(jsonPayload, ResourceGroupsManager.GlobalPropertiesDetail.class);
+      GlobalPropertiesDetail newGlobalProperty =
+          this.resourceGroupsManager.createGlobalProperty(globalProperty);
+      return Response.ok(newGlobalProperty).build();
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+      throw new WebApplicationException(e);
+    }
+  }
+
+  @GET
+  @Path("/globalproperty/read")
+  public Response readAllGlobalProperties() {
+    return Response.ok(this.resourceGroupsManager.readAllGlobalProperties()).build();
+  }
+
+  @GET
+  @Path("/globalproperty/read/{name}")
+  public Response readGlobalProperty(@PathParam("name") String name) {
+    if (Strings.isNullOrEmpty(name)) {
+      return Response.ok(this.resourceGroupsManager.readAllGlobalProperties()).build();
+    }
+    List<GlobalPropertiesDetail> globalProperty =
+        this.resourceGroupsManager.readGlobalProperty(name);
+    return Response.ok(globalProperty).build();
+  }
+
+  @Path("/globalproperty/update")
+  @POST
+  public Response updateGlobalProperty(String jsonPayload) {
+    try {
+      GlobalPropertiesDetail globalProperty =
+          OBJECT_MAPPER.readValue(jsonPayload, ResourceGroupsManager.GlobalPropertiesDetail.class);
+      GlobalPropertiesDetail updatedGlobalProperty =
+          this.resourceGroupsManager.updateGlobalProperty(globalProperty);
+      return Response.ok(updatedGlobalProperty).build();
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+      throw new WebApplicationException(e);
+    }
+  }
+
+  @Path("/globalproperty/delete/{name}")
+  @POST
+  public Response deleteGlobalProperty(@PathParam("name") String name) {
+    resourceGroupsManager.deleteGlobalProperty(name);
+    return Response.ok().build();
+  }
+
+  /* Unused API for ExactMatchSourceSelectors, as it is currently not used in Lyft
+    @POST
+    @Path("/exactmatchsourceselector/create")
+    public Response createExactMatchSourceSelector(String jsonPayload) {
+      try {
+        ExactSelectorsDetail exactMatchSourceSelector =
+                OBJECT_MAPPER.readValue(jsonPayload, ExactSelectorsDetail.class);
+        ExactSelectorsDetail newExactMatchSourceSelector =
+                this.resourceGroupsManager.createExactMatchSourceSelector(exactMatchSourceSelector);
+        return Response.ok(newExactMatchSourceSelector).build();
+      } catch (IOException e) {
+        log.error(e.getMessage(), e);
+        throw new WebApplicationException(e);
+      }
+    }
+
+    @POST
+    @Path("/exactmatchsourceselector/read")
+    public Response readExactMatchSourceSelector() {
+      return Response.ok(this.resourceGroupsManager.readExactMatchSourceSelector()).build();
+    }
+  */
+
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/PrestoResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/PrestoResource.java
@@ -1,0 +1,98 @@
+package com.lyft.data.gateway.ha.resource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import com.lyft.data.gateway.ha.persistence.dao.ResourceGroups;
+import com.lyft.data.gateway.ha.router.ResourceGroupsManager;
+import com.lyft.data.gateway.ha.router.ResourceGroupsManager.ResourceGroupsDetail;
+import com.lyft.data.gateway.ha.router.ResourceGroupsManager.SelectorsDetail;
+
+import java.io.IOException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Path("/presto")
+@Produces(MediaType.APPLICATION_JSON)
+// @Consumes(MediaType.APPLICATION_JSON)
+public class PrestoResource {
+  @Inject private ResourceGroupsManager resourceGroupsManager;
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @POST
+  @Path("/resourcegroup/create")
+  public Response createResourceGroup(String jsonPayload) {
+    try {
+      ResourceGroupsDetail resourceGroup =
+          OBJECT_MAPPER.readValue(jsonPayload, ResourceGroupsDetail.class);
+      ResourceGroupsDetail updatedResourceGroup =
+          this.resourceGroupsManager.createResourceGroup(resourceGroup);
+      return Response.ok(updatedResourceGroup).build();
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+      throw new WebApplicationException(e);
+    }
+  }
+
+  @GET
+  @Path("/resourcegroup/read")
+  public Response readResourceGroup() {
+    return Response.ok(this.resourceGroupsManager.readResourceGroup()).build();
+  }
+
+  @Path("/resourcegroup/update")
+  @POST
+  public Response updateResourceGroup(ResourceGroupsDetail resourceGroup) {
+    ResourceGroupsDetail updatedResourceGroup =
+        this.resourceGroupsManager.updateResourceGroup(resourceGroup);
+    return Response.ok(updatedResourceGroup).build();
+  }
+
+  @Path("/resourcegroup/delete")
+  @POST
+  public Response deleteResourceGroup(long resourceGroupId) {
+    resourceGroupsManager.deleteResourceGroup(resourceGroupId);
+    return Response.ok().build();
+  }
+  //
+  //  @POST
+  //  @Path("/selector/create")
+  //  public Response createSelector(String jsonPayload) {
+  //    try {
+  //      SelectorsDetail selector = OBJECT_MAPPER.readValue(jsonPayload, SelectorsDetail.class);
+  //      SelectorsDetail updatedSelector = this.resourceGroupsManager.createSelector(selector);
+  //      return Response.ok(updatedSelector).build();
+  //    } catch (IOException e) {
+  //      log.error(e.getMessage(), e);
+  //      throw new WebApplicationException(e);
+  //    }
+  //  }
+  //
+  //  @GET
+  //  @Path("/selector/read")
+  //  public Response readSelector() {
+  //    return Response.ok(this.resourceGroupsManager.readSelector()).build();
+  //  }
+
+  //  @Path("/selector/update")
+  //  @POST
+  //  public Response updateSelector(SelectorsDetail selector) {
+  //    SelectorsDetail updatedSelector = this.resourceGroupsManager.updateSelector(selector);
+  //    return Response.ok(updatedSelector).build();
+  //  }
+  //
+  //  @Path("/selector/delete")
+  //  @POST
+  //  public Response deleteSelector(long resourceGroupId) {
+  //    resourceGroupsManager.deleteSelector(resourceGroupId);
+  //    return Response.ok().build();
+  //  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaResourceGroupsManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaResourceGroupsManager.java
@@ -1,0 +1,269 @@
+package com.lyft.data.gateway.ha.router;
+
+import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
+import com.lyft.data.gateway.ha.persistence.dao.ExactMatchSourceSelectors;
+import com.lyft.data.gateway.ha.persistence.dao.ResourceGroups;
+import com.lyft.data.gateway.ha.persistence.dao.ResourceGroupsGlobalProperties;
+import com.lyft.data.gateway.ha.persistence.dao.Selectors;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class HaResourceGroupsManager implements ResourceGroupsManager {
+  private JdbcConnectionManager connectionManager;
+
+  public HaResourceGroupsManager(JdbcConnectionManager connectionManager) {
+    this.connectionManager = connectionManager;
+  }
+
+  /**
+   * Creates and returns a resource group with the given parameters.
+   *
+   * @param resourceGroup
+   * @return the created ResourceGroupDetail object
+   */
+  @Override
+  public ResourceGroupsDetail createResourceGroup(ResourceGroupsDetail resourceGroup) {
+    try {
+      connectionManager.open();
+      ResourceGroups.create(new ResourceGroups(), resourceGroup);
+    } finally {
+      connectionManager.close();
+    }
+    return resourceGroup;
+  }
+
+  /**
+   * Retrieves a list of all existing resource groups.
+   *
+   * @return all existing resource groups as a list of ResourceGroupDetail objects
+   */
+  @Override
+  public List<ResourceGroupsDetail> readResourceGroup() {
+    try {
+      connectionManager.open();
+      List<ResourceGroups> resourceGroupList = ResourceGroups.findAll();
+      return ResourceGroups.upcast(resourceGroupList);
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  /**
+   * Updates an existing resource group with new values.
+   *
+   * @param resourceGroup
+   * @return the updated ResourceGroupDetail object
+   */
+  @Override
+  public ResourceGroupsDetail updateResourceGroup(ResourceGroupsDetail resourceGroup) {
+    try {
+      connectionManager.open();
+      ResourceGroups model =
+          ResourceGroups.findFirst("resource_group_id = ?", resourceGroup.getResourceGroupId());
+
+      if (model == null) {
+        ResourceGroups.create(new ResourceGroups(), resourceGroup);
+      } else {
+        ResourceGroups.update(model, resourceGroup);
+      }
+    } finally {
+      connectionManager.close();
+    }
+    return resourceGroup;
+  }
+
+  /**
+   * Search for resource group by its resourceGroupId and delete it.
+   *
+   * @param resourceGroupId
+   */
+  @Override
+  public void deleteResourceGroup(long resourceGroupId) {
+    try {
+      connectionManager.open();
+      ResourceGroups.delete("resource_group_id = ?", resourceGroupId);
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  /**
+   * Creates and returns a selector with the given parameters.
+   *
+   * @param selector
+   * @return
+   */
+  @Override
+  public SelectorsDetail createSelector(SelectorsDetail selector) {
+    try {
+      connectionManager.open();
+      Selectors.create(new Selectors(), selector);
+    } finally {
+      connectionManager.close();
+    }
+    return selector;
+  }
+
+  /**
+   * Retrieves a list of all existing resource groups.
+   *
+   * @return all existing selectors as a list of SelectorDetail objects
+   */
+  @Override
+  public List<SelectorsDetail> readSelector() {
+    try {
+      connectionManager.open();
+      List<Selectors> selectorList = Selectors.findAll();
+      return Selectors.upcast(selectorList);
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  /**
+   * Updates an existing resource group with new values.
+   *
+   * @param selector
+   * @return
+   */
+  @Override
+  public SelectorsDetail updateSelector(SelectorsDetail selector) {
+    try {
+      connectionManager.open();
+      Selectors model = Selectors.findFirst("resource_group_id = ?", selector.getResourceGroupId());
+
+      if (model == null) {
+        Selectors.create(new Selectors(), selector);
+      } else {
+        Selectors.update(model, selector);
+      }
+    } finally {
+      connectionManager.close();
+    }
+    return selector;
+  }
+
+  /**
+   * Search for selector by its resourceGroupId and delete it.
+   *
+   * @param resourceGroupId
+   */
+  @Override
+  public void deleteSelector(long resourceGroupId) {
+    try {
+      connectionManager.open();
+      Selectors.delete("resource_group_id = ?", resourceGroupId);
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  @Override
+  public GlobalPropertiesDetail createGlobalProperty(GlobalPropertiesDetail globalPropertyDetail) {
+    try {
+      connectionManager.open();
+      ResourceGroupsGlobalProperties.create(
+          new ResourceGroupsGlobalProperties(), globalPropertyDetail);
+    } finally {
+      connectionManager.close();
+    }
+    return globalPropertyDetail;
+  }
+
+  @Override
+  public List<GlobalPropertiesDetail> readGlobalProperty() {
+    try {
+      connectionManager.open();
+      List<ResourceGroupsGlobalProperties> globalPropertyList =
+          ResourceGroupsGlobalProperties.findAll();
+      return ResourceGroupsGlobalProperties.upcast(globalPropertyList);
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  @Override
+  public GlobalPropertiesDetail updateGlobalProperty(GlobalPropertiesDetail globalProperty) {
+    try {
+      connectionManager.open();
+      ResourceGroupsGlobalProperties model =
+          ResourceGroupsGlobalProperties.findFirst("name = ?", globalProperty.getName());
+
+      if (model == null) {
+        ResourceGroupsGlobalProperties.create(new ResourceGroupsGlobalProperties(), globalProperty);
+      } else {
+        ResourceGroupsGlobalProperties.update(model, globalProperty);
+      }
+    } finally {
+      connectionManager.close();
+    }
+    return globalProperty;
+  }
+
+  @Override
+  public void deleteGlobalProperty(String name) {
+    try {
+      connectionManager.open();
+      ResourceGroupsGlobalProperties.delete("name = ?", name);
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  @Override
+  public ExactSelectorsDetail createExactMatchSourceSelector(
+      ExactSelectorsDetail exactSelectorDetail) {
+    try {
+      connectionManager.open();
+      ExactMatchSourceSelectors.create(new ExactMatchSourceSelectors(), exactSelectorDetail);
+    } finally {
+      connectionManager.close();
+    }
+    return exactSelectorDetail;
+  }
+
+  @Override
+  public List<ExactSelectorsDetail> readExactMatchSourceSelector() {
+    try {
+      connectionManager.open();
+      List<ExactMatchSourceSelectors> exactMatchSourceSelectorList =
+          ExactMatchSourceSelectors.findAll();
+      return ExactMatchSourceSelectors.upcast(exactMatchSourceSelectorList);
+    } finally {
+      connectionManager.close();
+    }
+  }
+
+  @Override
+  public ExactSelectorsDetail updateExactMatchSourceSelector(
+      ExactSelectorsDetail exactSelectorDetail) {
+    try {
+      connectionManager.open();
+      ExactMatchSourceSelectors model =
+          ExactMatchSourceSelectors.findFirst(
+              "environment = ?",
+              exactSelectorDetail.getEnvironment()); // TODO: change to multiple primary keys
+
+      if (model == null) {
+        ExactMatchSourceSelectors.create(new ExactMatchSourceSelectors(), exactSelectorDetail);
+      } else {
+        ExactMatchSourceSelectors.update(model, exactSelectorDetail);
+      }
+    } finally {
+      connectionManager.close();
+    }
+    return exactSelectorDetail;
+  }
+
+  @Override
+  public void deleteExactMatchSourceSelector(String environment) {
+    try {
+      connectionManager.open();
+      ExactMatchSourceSelectors.delete("environment = ?", environment);
+    } finally {
+      connectionManager.close();
+    }
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaResourceGroupsManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaResourceGroupsManager.java
@@ -2,7 +2,6 @@ package com.lyft.data.gateway.ha.router;
 
 import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
 import com.lyft.data.gateway.ha.persistence.dao.ExactMatchSourceSelectors;
-import com.lyft.data.gateway.ha.persistence.dao.GatewayBackend;
 import com.lyft.data.gateway.ha.persistence.dao.ResourceGroups;
 import com.lyft.data.gateway.ha.persistence.dao.ResourceGroupsGlobalProperties;
 import com.lyft.data.gateway.ha.persistence.dao.Selectors;

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaResourceGroupsManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaResourceGroupsManager.java
@@ -191,6 +191,12 @@ public class HaResourceGroupsManager implements ResourceGroupsManager {
     }
   }
 
+  /**
+   * Create new global property with given parameters.
+   *
+   * @param globalPropertyDetail
+   * @return created global property
+   */
   @Override
   public GlobalPropertiesDetail createGlobalProperty(GlobalPropertiesDetail globalPropertyDetail) {
     try {
@@ -203,6 +209,11 @@ public class HaResourceGroupsManager implements ResourceGroupsManager {
     return globalPropertyDetail;
   }
 
+  /**
+   * Read all existing global properties.
+   *
+   * @return a list of global properties
+   */
   @Override
   public List<GlobalPropertiesDetail> readAllGlobalProperties() {
     try {
@@ -215,6 +226,12 @@ public class HaResourceGroupsManager implements ResourceGroupsManager {
     }
   }
 
+  /**
+   * Read specific global property based on the given name.
+   *
+   * @param name
+   * @return corresponding global property
+   */
   @Override
   public List<GlobalPropertiesDetail> readGlobalProperty(String name) {
     try {
@@ -227,6 +244,12 @@ public class HaResourceGroupsManager implements ResourceGroupsManager {
     }
   }
 
+  /**
+   * Updates a global property based on the given name.
+   *
+   * @param globalProperty
+   * @return the updated global property
+   */
   @Override
   public GlobalPropertiesDetail updateGlobalProperty(GlobalPropertiesDetail globalProperty) {
     try {
@@ -245,6 +268,11 @@ public class HaResourceGroupsManager implements ResourceGroupsManager {
     return globalProperty;
   }
 
+  /**
+   * Deletes a global property from the table based on its name.
+   *
+   * @param name
+   */
   @Override
   public void deleteGlobalProperty(String name) {
     try {
@@ -300,8 +328,7 @@ public class HaResourceGroupsManager implements ResourceGroupsManager {
       if (model == null) {
         return null;
       } else {
-        ExactMatchSourceSelectors.upcast(
-            exactMatchSourceSelectorList);
+        ExactMatchSourceSelectors.upcast(exactMatchSourceSelectorList);
       }
     } finally {
       connectionManager.close();

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/ResourceGroupsManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/ResourceGroupsManager.java
@@ -1,0 +1,138 @@
+package com.lyft.data.gateway.ha.router;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+public interface ResourceGroupsManager {
+  ResourceGroupsDetail createResourceGroup(ResourceGroupsDetail resourceGroup);
+
+  List<ResourceGroupsDetail> readResourceGroup();
+
+  ResourceGroupsDetail updateResourceGroup(ResourceGroupsDetail resourceGroup);
+
+  void deleteResourceGroup(long resourceGroupId);
+
+  SelectorsDetail createSelector(SelectorsDetail selector);
+
+  List<SelectorsDetail> readSelector();
+
+  SelectorsDetail updateSelector(SelectorsDetail selector);
+
+  void deleteSelector(long resourceGroupId);
+
+  GlobalPropertiesDetail createGlobalProperty(GlobalPropertiesDetail globalPropertyDetail);
+
+  List<GlobalPropertiesDetail> readGlobalProperty();
+
+  GlobalPropertiesDetail updateGlobalProperty(GlobalPropertiesDetail globalProperty);
+
+  void deleteGlobalProperty(String name);
+
+  ExactSelectorsDetail createExactMatchSourceSelector(ExactSelectorsDetail exactSelectorDetail);
+
+  List<ExactSelectorsDetail> readExactMatchSourceSelector();
+
+  ExactSelectorsDetail updateExactMatchSourceSelector(ExactSelectorsDetail exactSelectorDetail);
+
+  void deleteExactMatchSourceSelector(String environment); // TODO: change this to multiple params
+
+  @RequiredArgsConstructor
+  @Data
+  @ToString
+  class ResourceGroupsDetail implements Comparable<ResourceGroupsDetail> {
+    @NonNull private long resourceGroupId;
+    @NonNull private String name;
+
+    /* OPTIONAL POLICY CONTROLS */
+    private long parent;
+    private boolean jmxExport;
+    private String schedulingPolicy;
+    private int schedulingWeight;
+
+    /* REQUIRED QUOTAS */
+    @NonNull private String softMemoryLimit;
+    @NonNull private int maxQueued;
+    @NonNull private int hardConcurrencyLimit;
+
+    /* OPTIONAL QUOTAS */
+    private int softConcurrencyLimit;
+    private String softCpuLimit;
+    private String hardCpuLimit;
+    private String environment;
+
+    public ResourceGroupsDetail() {}
+
+    @Override
+    public int compareTo(ResourceGroupsDetail o) {
+      if (this.resourceGroupId < o.resourceGroupId) {
+        return 1;
+      } else {
+        return this.resourceGroupId == o.resourceGroupId ? 0 : -1;
+      }
+    }
+  }
+
+  @RequiredArgsConstructor
+  @Data
+  @ToString
+  class SelectorsDetail implements Comparable<SelectorsDetail> {
+    @NonNull private long resourceGroupId;
+    @NonNull private long priority;
+
+    private String userRegex;
+    private String sourceRegex;
+
+    private String queryType;
+    private String clientTags;
+    private String selectorResourceEstimate;
+
+    public SelectorsDetail() {}
+
+    @Override
+    public int compareTo(SelectorsDetail o) {
+      if (this.resourceGroupId < o.resourceGroupId) {
+        return 1;
+      } else {
+        return this.resourceGroupId == o.resourceGroupId ? 0 : -1;
+      }
+    }
+  }
+
+  @RequiredArgsConstructor
+  @Data
+  @ToString
+  class GlobalPropertiesDetail implements Comparable<GlobalPropertiesDetail> {
+    @NonNull private String name;
+    private String value;
+
+    public GlobalPropertiesDetail() {}
+
+    @Override
+    public int compareTo(GlobalPropertiesDetail o) {
+      return 0;
+    }
+  }
+
+  @RequiredArgsConstructor
+  @Data
+  @ToString
+  class ExactSelectorsDetail implements Comparable<ExactSelectorsDetail> {
+    @NonNull private String resourceGroupId;
+    @NonNull private String updateTime;
+
+    @NonNull private String source;
+    private String environment;
+    private String queryType;
+
+    public ExactSelectorsDetail() {}
+
+    @Override
+    public int compareTo(ExactSelectorsDetail o) {
+      return 0;
+    }
+  }
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/ResourceGroupsManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/ResourceGroupsManager.java
@@ -10,7 +10,9 @@ import lombok.ToString;
 public interface ResourceGroupsManager {
   ResourceGroupsDetail createResourceGroup(ResourceGroupsDetail resourceGroup);
 
-  List<ResourceGroupsDetail> readResourceGroup();
+  List<ResourceGroupsDetail> readAllResourceGroups();
+
+  List<ResourceGroupsDetail> readResourceGroup(long resourceGroupId);
 
   ResourceGroupsDetail updateResourceGroup(ResourceGroupsDetail resourceGroup);
 
@@ -18,7 +20,9 @@ public interface ResourceGroupsManager {
 
   SelectorsDetail createSelector(SelectorsDetail selector);
 
-  List<SelectorsDetail> readSelector();
+  List<SelectorsDetail> readAllSelectors();
+
+  List<SelectorsDetail> readSelector(long resourceGroupId);
 
   SelectorsDetail updateSelector(SelectorsDetail selector);
 
@@ -26,7 +30,9 @@ public interface ResourceGroupsManager {
 
   GlobalPropertiesDetail createGlobalProperty(GlobalPropertiesDetail globalPropertyDetail);
 
-  List<GlobalPropertiesDetail> readGlobalProperty();
+  List<GlobalPropertiesDetail> readAllGlobalProperties();
+
+  List<GlobalPropertiesDetail> readGlobalProperty(String name);
 
   GlobalPropertiesDetail updateGlobalProperty(GlobalPropertiesDetail globalProperty);
 
@@ -36,9 +42,7 @@ public interface ResourceGroupsManager {
 
   List<ExactSelectorsDetail> readExactMatchSourceSelector();
 
-  ExactSelectorsDetail updateExactMatchSourceSelector(ExactSelectorsDetail exactSelectorDetail);
-
-  void deleteExactMatchSourceSelector(String environment); // TODO: change this to multiple params
+  ExactSelectorsDetail getExactMatchSourceSelector(ExactSelectorsDetail exactSelectorDetail);
 
   @RequiredArgsConstructor
   @Data
@@ -48,10 +52,10 @@ public interface ResourceGroupsManager {
     @NonNull private String name;
 
     /* OPTIONAL POLICY CONTROLS */
-    private long parent;
-    private boolean jmxExport;
+    private Long parent;
+    private Boolean jmxExport;
     private String schedulingPolicy;
-    private int schedulingWeight;
+    private Integer schedulingWeight;
 
     /* REQUIRED QUOTAS */
     @NonNull private String softMemoryLimit;
@@ -59,7 +63,7 @@ public interface ResourceGroupsManager {
     @NonNull private int hardConcurrencyLimit;
 
     /* OPTIONAL QUOTAS */
-    private int softConcurrencyLimit;
+    private Integer softConcurrencyLimit;
     private String softCpuLimit;
     private String hardCpuLimit;
     private String environment;

--- a/gateway-ha/src/main/resources/00-resource_groups.sql
+++ b/gateway-ha/src/main/resources/00-resource_groups.sql
@@ -1,0 +1,29 @@
+-- Schema inlined in presto in:
+--    presto-resource-group-managers/src/main/java/io/prestosql/plugin
+--      /resourcegropus/db/ResourceGroupsDao.java
+CREATE TABLE IF NOT EXISTS resource_groups (
+    resource_group_id BIGINT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(250) NOT NULL UNIQUE,
+
+    -- OPTIONAL POLICY CONTROLS
+    parent BIGINT NULL,
+    jmx_export BOOLEAN NULL,
+    scheduling_policy VARCHAR(128) NULL,
+    scheduling_weight INT NULL,
+
+    -- REQUIRED QUOTAS
+    soft_memory_limit VARCHAR(128) NOT NULL,
+    max_queued INT NOT NULL,
+    hard_concurrency_limit INT NOT NULL,
+
+    -- OPTIONAL QUOTAS
+    soft_concurrency_limit INT NULL,
+    soft_cpu_limit VARCHAR(128) NULL,
+    hard_cpu_limit VARCHAR(128) NULL,
+    environment VARCHAR(128) NULL,
+
+    PRIMARY KEY(resource_group_id),
+--    KEY(name),
+    FOREIGN KEY (parent) REFERENCES resource_groups (resource_group_id)
+)
+

--- a/gateway-ha/src/main/resources/gateway-ha-persistence.sql
+++ b/gateway-ha/src/main/resources/gateway-ha-persistence.sql
@@ -15,3 +15,64 @@ user_name VARCHAR(256),
 source VARCHAR(256)
 );
 CREATE INDEX query_history_created_idx ON query_history(created);
+
+CREATE TABLE IF NOT EXISTS resource_groups (
+    resource_group_id BIGINT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(250) NOT NULL UNIQUE,
+
+    -- OPTIONAL POLICY CONTROLS
+    parent BIGINT NULL,
+    jmx_export BOOLEAN NULL,
+    scheduling_policy VARCHAR(128) NULL,
+    scheduling_weight INT NULL,
+
+    -- REQUIRED QUOTAS
+    soft_memory_limit VARCHAR(128) NOT NULL,
+    max_queued INT NOT NULL,
+    hard_concurrency_limit INT NOT NULL,
+
+    -- OPTIONAL QUOTAS
+    soft_concurrency_limit INT NULL,
+    soft_cpu_limit VARCHAR(128) NULL,
+    hard_cpu_limit VARCHAR(128) NULL,
+    environment VARCHAR(128) NULL,
+
+    PRIMARY KEY(resource_group_id),
+    FOREIGN KEY (parent) REFERENCES resource_groups (resource_group_id)
+);
+
+CREATE TABLE IF NOT EXISTS selectors (
+    resource_group_id BIGINT NOT NULL,
+    priority BIGINT NOT NULL,
+
+    -- Regex fields -- these will be used as a regular expression pattern to
+    --                 match against the field of the same name on queries
+    user_regex VARCHAR(512),
+    source_regex VARCHAR(512),
+
+    -- Selector fields -- these must match exactly.
+    query_type VARCHAR(512),
+    client_tags VARCHAR(512),
+    selector_resource_estimate VARCHAR(1024),
+
+    FOREIGN KEY (resource_group_id) REFERENCES resource_groups(resource_group_id)
+);
+
+CREATE TABLE IF NOT EXISTS resource_groups_global_properties (
+    name VARCHAR(128) NOT NULL PRIMARY KEY,
+    value VARCHAR(512) NULL,
+    CHECK (name in ('cpu_quota_period'))
+);
+
+CREATE TABLE IF NOT EXISTS exact_match_source_selectors (
+    resource_group_id VARCHAR(256) NOT NULL,  -- WTF varchar?!
+    update_time DATETIME NOT NULL,
+
+    -- Selector fields which must exactly match a query
+    source VARCHAR(512) NOT NULL,
+    environment VARCHAR(128),
+    query_type VARCHAR(128), -- (reduced from 512)
+
+    PRIMARY KEY (environment, source, query_type),
+    UNIQUE (source, environment, query_type, resource_group_id)
+);

--- a/gateway-ha/src/migrations/gateway-ha.sql
+++ b/gateway-ha/src/migrations/gateway-ha.sql
@@ -17,3 +17,64 @@ user_name VARCHAR(256),
 source VARCHAR(256)
 );
 CREATE INDEX query_history_created_idx ON query_history(created);
+
+CREATE TABLE IF NOT EXISTS resource_groups (
+    resource_group_id BIGINT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(250) NOT NULL UNIQUE,
+
+    -- OPTIONAL POLICY CONTROLS
+    parent BIGINT NULL,
+    jmx_export BOOLEAN NULL,
+    scheduling_policy VARCHAR(128) NULL,
+    scheduling_weight INT NULL,
+
+    -- REQUIRED QUOTAS
+    soft_memory_limit VARCHAR(128) NOT NULL,
+    max_queued INT NOT NULL,
+    hard_concurrency_limit INT NOT NULL,
+
+    -- OPTIONAL QUOTAS
+    soft_concurrency_limit INT NULL,
+    soft_cpu_limit VARCHAR(128) NULL,
+    hard_cpu_limit VARCHAR(128) NULL,
+    environment VARCHAR(128) NULL,
+
+    PRIMARY KEY(resource_group_id),
+    FOREIGN KEY (parent) REFERENCES resource_groups (resource_group_id)
+);
+
+CREATE TABLE IF NOT EXISTS selectors (
+    resource_group_id BIGINT NOT NULL,
+    priority BIGINT NOT NULL,
+
+    -- Regex fields -- these will be used as a regular expression pattern to
+    --                 match against the field of the same name on queries
+    user_regex VARCHAR(512),
+    source_regex VARCHAR(512),
+
+    -- Selector fields -- these must match exactly.
+    query_type VARCHAR(512),
+    client_tags VARCHAR(512),
+    selector_resource_estimate VARCHAR(1024),
+
+    FOREIGN KEY (resource_group_id) REFERENCES resource_groups(resource_group_id)
+);
+
+CREATE TABLE IF NOT EXISTS resource_groups_global_properties (
+    name VARCHAR(128) NOT NULL PRIMARY KEY,
+    value VARCHAR(512) NULL,
+    CHECK (name in ('cpu_quota_period'))
+);
+
+CREATE TABLE IF NOT EXISTS exact_match_source_selectors (
+    resource_group_id VARCHAR(256) NOT NULL,  -- WTF varchar?!
+    update_time DATETIME NOT NULL,
+
+    -- Selector fields which must exactly match a query
+    source VARCHAR(512) NOT NULL,
+    environment VARCHAR(128),
+    query_type VARCHAR(128), -- (reduced from 512)
+
+    PRIMARY KEY (environment, source, query_type),
+    UNIQUE (source, environment, query_type, resource_group_id)
+);

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestResourceGroupManager.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestResourceGroupManager.java
@@ -1,0 +1,292 @@
+package com.lyft.data.gateway.ha.router;
+
+import static com.lyft.data.gateway.ha.router.ResourceGroupsManager.ExactSelectorsDetail;
+import static com.lyft.data.gateway.ha.router.ResourceGroupsManager.GlobalPropertiesDetail;
+import static com.lyft.data.gateway.ha.router.ResourceGroupsManager.ResourceGroupsDetail;
+import static com.lyft.data.gateway.ha.router.ResourceGroupsManager.SelectorsDetail;
+
+import com.lyft.data.gateway.ha.HaGatewayTestUtils;
+import com.lyft.data.gateway.ha.config.DataStoreConfiguration;
+import com.lyft.data.gateway.ha.persistence.JdbcConnectionManager;
+import java.io.File;
+import java.util.List;
+import java.util.logging.Logger;
+
+import lombok.extern.slf4j.Slf4j;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test
+public class TestResourceGroupManager {
+  private ResourceGroupsManager resourceGroupManager;
+  private static final Logger logger = Logger.getLogger(TestResourceGroupManager.class.getName());
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    File baseDir = new File(System.getProperty("java.io.tmpdir"));
+    File tempH2DbDir = new File(baseDir, "h2db-" + System.currentTimeMillis());
+    tempH2DbDir.deleteOnExit();
+    String jdbcUrl = "jdbc:h2:" + tempH2DbDir.getAbsolutePath();
+    HaGatewayTestUtils.seedRequiredData(
+        new HaGatewayTestUtils.TestConfig("", tempH2DbDir.getAbsolutePath()));
+    DataStoreConfiguration db = new DataStoreConfiguration(jdbcUrl, "sa", "sa", "org.h2.Driver");
+    JdbcConnectionManager connectionManager = new JdbcConnectionManager(db);
+    resourceGroupManager = new HaResourceGroupsManager(connectionManager);
+  }
+
+  public void testCreateResourceGroup() {
+    ResourceGroupsDetail resourceGroup = new ResourceGroupsDetail();
+
+    resourceGroup.setResourceGroupId(0L);
+    resourceGroup.setName("admin");
+    resourceGroup.setHardConcurrencyLimit(20);
+    resourceGroup.setMaxQueued(200);
+    resourceGroup.setJmxExport(true);
+    resourceGroup.setSoftMemoryLimit("80%");
+
+    ResourceGroupsDetail newResourceGroup = resourceGroupManager.createResourceGroup(resourceGroup);
+
+    Assert.assertEquals(newResourceGroup, resourceGroup);
+  }
+
+  @Test(dependsOnMethods = {"testCreateResourceGroup"})
+  public void testReadResourceGroup() {
+    List<ResourceGroupsDetail> resourceGroups = resourceGroupManager.readResourceGroup();
+    Assert.assertEquals(resourceGroups.size(), 1);
+
+    Assert.assertEquals(resourceGroups.get(0).getResourceGroupId(), 0L);
+    Assert.assertEquals(resourceGroups.get(0).getName(), "admin");
+    Assert.assertEquals(resourceGroups.get(0).getHardConcurrencyLimit(), 20);
+    Assert.assertEquals(resourceGroups.get(0).getMaxQueued(), 200);
+    Assert.assertEquals(resourceGroups.get(0).isJmxExport(), true);
+    Assert.assertEquals(resourceGroups.get(0).getSoftMemoryLimit(), "80%");
+  }
+
+  @Test(dependsOnMethods = {"testReadResourceGroup"})
+  public void testUpdateResourceGroup() {
+    ResourceGroupsDetail resourceGroup = new ResourceGroupsDetail();
+    resourceGroup.setResourceGroupId(0L);
+    resourceGroup.setName("admin");
+    resourceGroup.setHardConcurrencyLimit(50);
+    resourceGroup.setMaxQueued(50);
+    resourceGroup.setJmxExport(false);
+    resourceGroup.setSoftMemoryLimit("20%");
+
+    ResourceGroupsDetail updated = resourceGroupManager.updateResourceGroup(resourceGroup);
+    List<ResourceGroupsDetail> resourceGroups = resourceGroupManager.readResourceGroup();
+    Assert.assertEquals(resourceGroups.size(), 1);
+    Assert.assertEquals(updated, resourceGroup);
+
+    /* Update resourceGroups that do not exist yet.
+     *  In this case, new resourceGroups should be created. */
+    resourceGroup.setResourceGroupId(1L);
+    resourceGroup.setName("localization-eng");
+    resourceGroup.setHardConcurrencyLimit(50);
+    resourceGroup.setMaxQueued(70);
+    resourceGroup.setJmxExport(true);
+    resourceGroup.setSoftMemoryLimit("20%");
+    resourceGroup.setSoftConcurrencyLimit(20);
+    resourceGroupManager.updateResourceGroup(resourceGroup);
+
+    resourceGroup.setResourceGroupId(3L);
+    resourceGroup.setName("resource_group_3");
+    resourceGroup.setHardConcurrencyLimit(10);
+    resourceGroup.setMaxQueued(150);
+    resourceGroup.setJmxExport(true);
+    resourceGroup.setSoftMemoryLimit("60%");
+    resourceGroup.setSoftConcurrencyLimit(40);
+    resourceGroupManager.updateResourceGroup(resourceGroup);
+
+    resourceGroups = resourceGroupManager.readResourceGroup();
+
+    Assert.assertEquals(
+        resourceGroups.size(), 3); // updated 2 non-existing groups, so count should be 3
+
+    Assert.assertEquals(resourceGroups.get(0).getResourceGroupId(), 0L);
+    Assert.assertEquals(resourceGroups.get(0).getName(), "admin");
+    Assert.assertEquals(resourceGroups.get(0).getHardConcurrencyLimit(), 50);
+    Assert.assertEquals(resourceGroups.get(0).getMaxQueued(), 50);
+    Assert.assertEquals(resourceGroups.get(0).isJmxExport(), false);
+    Assert.assertEquals(resourceGroups.get(0).getSoftMemoryLimit(), "20%");
+
+    Assert.assertEquals(resourceGroups.get(1).getResourceGroupId(), 1L);
+    Assert.assertEquals(resourceGroups.get(1).getName(), "localization-eng");
+    Assert.assertEquals(resourceGroups.get(1).getHardConcurrencyLimit(), 50);
+    Assert.assertEquals(resourceGroups.get(1).getMaxQueued(), 70);
+    Assert.assertEquals(resourceGroups.get(1).isJmxExport(), true);
+    Assert.assertEquals(resourceGroups.get(1).getSoftMemoryLimit(), "20%");
+    Assert.assertEquals(resourceGroups.get(1).getSoftConcurrencyLimit(), 20);
+  }
+
+  @Test(dependsOnMethods = {"testUpdateResourceGroup"})
+  public void testDeleteResourceGroup() {
+    List<ResourceGroupsDetail> resourceGroups = resourceGroupManager.readResourceGroup();
+    Assert.assertEquals(resourceGroups.size(), 3);
+
+    Assert.assertEquals(resourceGroups.get(0).getResourceGroupId(), 0L);
+    Assert.assertEquals(resourceGroups.get(1).getResourceGroupId(), 1L);
+    Assert.assertEquals(resourceGroups.get(2).getResourceGroupId(), 3L);
+
+    resourceGroupManager.deleteResourceGroup(resourceGroups.get(1).getResourceGroupId());
+    resourceGroups = resourceGroupManager.readResourceGroup();
+
+    Assert.assertEquals(resourceGroups.size(), 2);
+    Assert.assertEquals(resourceGroups.get(0).getResourceGroupId(), 0L);
+    Assert.assertEquals(resourceGroups.get(1).getResourceGroupId(), 3L);
+
+    resourceGroupManager.deleteResourceGroup(resourceGroups.get(1).getResourceGroupId());
+    resourceGroups = resourceGroupManager.readResourceGroup();
+
+    Assert.assertEquals(resourceGroups.size(), 1);
+    Assert.assertEquals(resourceGroups.get(0).getResourceGroupId(), 0L);
+  }
+
+  @Test(dependsOnMethods = {"testCreateResourceGroup"})
+  public void testCreateSelector() {
+    SelectorsDetail selector = new SelectorsDetail();
+    selector.setResourceGroupId(0L);
+    selector.setPriority(0L);
+    selector.setUserRegex("data-platform-admin");
+    selector.setSourceRegex("admin");
+    selector.setQueryType("query_type");
+    selector.setClientTags("client_tag");
+    selector.setSelectorResourceEstimate("estimate");
+
+    SelectorsDetail newSelector = resourceGroupManager.createSelector(selector);
+
+    Assert.assertEquals(newSelector, selector);
+  }
+
+  @Test(dependsOnMethods = {"testCreateSelector"})
+  public void testReadSelector() {
+    List<SelectorsDetail> selectors = resourceGroupManager.readSelector();
+
+    Assert.assertEquals(selectors.size(), 1);
+    Assert.assertEquals(selectors.get(0).getResourceGroupId(), 0L);
+    Assert.assertEquals(selectors.get(0).getPriority(), 0L);
+    Assert.assertEquals(selectors.get(0).getUserRegex(), "data-platform-admin");
+    Assert.assertEquals(selectors.get(0).getSourceRegex(), "admin");
+    Assert.assertEquals(selectors.get(0).getQueryType(), "query_type");
+    Assert.assertEquals(selectors.get(0).getClientTags(), "client_tag");
+    Assert.assertEquals(selectors.get(0).getSelectorResourceEstimate(), "estimate");
+  }
+
+  @Test(dependsOnMethods = {"testReadSelector"})
+  public void testUpdateSelector() {
+    SelectorsDetail selector = new SelectorsDetail();
+
+    selector.setResourceGroupId(0L);
+    selector.setPriority(0L);
+    selector.setUserRegex("data-platform-admin_updated");
+    selector.setSourceRegex("admin_updated");
+    selector.setQueryType("query_type_updated");
+    selector.setClientTags("client_tag_updated");
+    selector.setSelectorResourceEstimate("estimate_updated");
+
+    SelectorsDetail updated = resourceGroupManager.updateSelector(selector);
+    List<SelectorsDetail> selectors = resourceGroupManager.readSelector();
+
+    Assert.assertEquals(selectors.size(), 1);
+    Assert.assertEquals(updated, selectors.get(0));
+  }
+
+  @Test(dependsOnMethods = {"testUpdateSelector"})
+  public void testDeleteSelector() {
+    List<SelectorsDetail> selectors = resourceGroupManager.readSelector();
+    Assert.assertEquals(selectors.size(), 1);
+    Assert.assertEquals(selectors.get(0).getResourceGroupId(), 0L);
+    resourceGroupManager.deleteSelector(selectors.get(0).getResourceGroupId());
+    selectors = resourceGroupManager.readSelector();
+
+    Assert.assertEquals(selectors.size(), 0);
+  }
+
+  public void testCreateGlobalProperties() {
+    GlobalPropertiesDetail globalPropertiesDetail = new GlobalPropertiesDetail();
+    globalPropertiesDetail.setName("cpu_quota_period");
+    globalPropertiesDetail.setValue("1h");
+
+    GlobalPropertiesDetail newGlobalProperties =
+        resourceGroupManager.createGlobalProperty(globalPropertiesDetail);
+
+    Assert.assertEquals(newGlobalProperties, globalPropertiesDetail);
+
+    try { // make sure that the name is cpu_quota_period
+      GlobalPropertiesDetail invalidGlobalProperty = new GlobalPropertiesDetail();
+      invalidGlobalProperty.setName("invalid_property");
+      invalidGlobalProperty.setValue("1h");
+      resourceGroupManager.createGlobalProperty(invalidGlobalProperty);
+    } catch (Exception ex) {
+      logger.info(ex.toString());
+      Assert.assertTrue(ex.getCause() instanceof org.h2.jdbc.JdbcSQLException);
+      Assert.assertTrue(ex.getCause().getMessage().startsWith("Check constraint violation:"));
+    }
+  }
+
+  @Test(dependsOnMethods = {"testCreateGlobalProperties"})
+  public void testReadGlobalProperties() {
+    List<GlobalPropertiesDetail> globalProperties = resourceGroupManager.readGlobalProperty();
+
+    Assert.assertEquals(globalProperties.size(), 1);
+    Assert.assertEquals(globalProperties.get(0).getName(), "cpu_quota_period");
+    Assert.assertEquals(globalProperties.get(0).getValue(), "1h");
+  }
+
+  @Test(dependsOnMethods = {"testReadGlobalProperties"})
+  public void testUpdateGlobalProperties() {
+    GlobalPropertiesDetail globalPropertiesDetail = new GlobalPropertiesDetail();
+    globalPropertiesDetail.setName("cpu_quota_period");
+    globalPropertiesDetail.setValue("updated_test_value");
+
+    GlobalPropertiesDetail updated =
+        resourceGroupManager.updateGlobalProperty(globalPropertiesDetail);
+    List<GlobalPropertiesDetail> globalProperties = resourceGroupManager.readGlobalProperty();
+
+    Assert.assertEquals(globalProperties.size(), 1);
+    Assert.assertEquals(updated, globalProperties.get(0));
+
+    try { // make sure that the name is cpu_quota_period
+      GlobalPropertiesDetail invalidGlobalProperty = new GlobalPropertiesDetail();
+      invalidGlobalProperty.setName("invalid_property");
+      invalidGlobalProperty.setValue("1h");
+      resourceGroupManager.updateGlobalProperty(invalidGlobalProperty);
+    } catch (Exception ex) {
+      logger.info(ex.toString());
+      Assert.assertTrue(ex.getCause() instanceof org.h2.jdbc.JdbcSQLException);
+      Assert.assertTrue(ex.getCause().getMessage().startsWith("Check constraint violation:"));
+    }
+  }
+
+  public void testCreateExactMatchSourceSelectors() {
+    ExactSelectorsDetail exactSelectorDetail = new ExactSelectorsDetail();
+
+    exactSelectorDetail.setResourceGroupId("0");
+    exactSelectorDetail.setUpdateTime("2020-07-06");
+    exactSelectorDetail.setSource("@test@test_pipeline");
+    exactSelectorDetail.setEnvironment("test");
+    exactSelectorDetail.setQueryType("query_type");
+
+    ExactSelectorsDetail newExactMatchSourceSelector =
+        resourceGroupManager.createExactMatchSourceSelector(exactSelectorDetail);
+
+    Assert.assertEquals(newExactMatchSourceSelector, exactSelectorDetail);
+  }
+
+  @Test(dependsOnMethods = {"testCreateExactMatchSourceSelectors"})
+  public void testReadExactMatchSourceSelectors() {
+    List<ExactSelectorsDetail> exactSelectorsDetails =
+        resourceGroupManager.readExactMatchSourceSelector();
+
+    Assert.assertEquals(exactSelectorsDetails.size(), 1);
+    Assert.assertEquals(exactSelectorsDetails.get(0).getResourceGroupId(), "0");
+    Assert.assertEquals(exactSelectorsDetails.get(0).getSource(), "@test@test_pipeline");
+    Assert.assertEquals(exactSelectorsDetails.get(0).getEnvironment(), "test");
+    Assert.assertEquals(exactSelectorsDetails.get(0).getQueryType(), "query_type");
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {}
+}

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestResourceGroupsManager.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestResourceGroupsManager.java
@@ -20,9 +20,8 @@ import org.testng.annotations.Test;
 
 @Slf4j
 @Test
-public class TestResourceGroupManager {
+public class TestResourceGroupsManager {
   private ResourceGroupsManager resourceGroupManager;
-  private static final Logger logger = Logger.getLogger(TestResourceGroupManager.class.getName());
 
   @BeforeClass(alwaysRun = true)
   public void setUp() {
@@ -54,14 +53,14 @@ public class TestResourceGroupManager {
 
   @Test(dependsOnMethods = {"testCreateResourceGroup"})
   public void testReadResourceGroup() {
-    List<ResourceGroupsDetail> resourceGroups = resourceGroupManager.readResourceGroup();
+    List<ResourceGroupsDetail> resourceGroups = resourceGroupManager.readAllResourceGroups();
     Assert.assertEquals(resourceGroups.size(), 1);
 
     Assert.assertEquals(resourceGroups.get(0).getResourceGroupId(), 0L);
     Assert.assertEquals(resourceGroups.get(0).getName(), "admin");
     Assert.assertEquals(resourceGroups.get(0).getHardConcurrencyLimit(), 20);
     Assert.assertEquals(resourceGroups.get(0).getMaxQueued(), 200);
-    Assert.assertEquals(resourceGroups.get(0).isJmxExport(), true);
+    Assert.assertEquals(resourceGroups.get(0).getJmxExport(), Boolean.TRUE);
     Assert.assertEquals(resourceGroups.get(0).getSoftMemoryLimit(), "80%");
   }
 
@@ -76,7 +75,7 @@ public class TestResourceGroupManager {
     resourceGroup.setSoftMemoryLimit("20%");
 
     ResourceGroupsDetail updated = resourceGroupManager.updateResourceGroup(resourceGroup);
-    List<ResourceGroupsDetail> resourceGroups = resourceGroupManager.readResourceGroup();
+    List<ResourceGroupsDetail> resourceGroups = resourceGroupManager.readAllResourceGroups();
     Assert.assertEquals(resourceGroups.size(), 1);
     Assert.assertEquals(updated, resourceGroup);
 
@@ -100,7 +99,7 @@ public class TestResourceGroupManager {
     resourceGroup.setSoftConcurrencyLimit(40);
     resourceGroupManager.updateResourceGroup(resourceGroup);
 
-    resourceGroups = resourceGroupManager.readResourceGroup();
+    resourceGroups = resourceGroupManager.readAllResourceGroups();
 
     Assert.assertEquals(
         resourceGroups.size(), 3); // updated 2 non-existing groups, so count should be 3
@@ -109,21 +108,21 @@ public class TestResourceGroupManager {
     Assert.assertEquals(resourceGroups.get(0).getName(), "admin");
     Assert.assertEquals(resourceGroups.get(0).getHardConcurrencyLimit(), 50);
     Assert.assertEquals(resourceGroups.get(0).getMaxQueued(), 50);
-    Assert.assertEquals(resourceGroups.get(0).isJmxExport(), false);
+    Assert.assertEquals(resourceGroups.get(0).getJmxExport(), Boolean.FALSE);
     Assert.assertEquals(resourceGroups.get(0).getSoftMemoryLimit(), "20%");
 
     Assert.assertEquals(resourceGroups.get(1).getResourceGroupId(), 1L);
     Assert.assertEquals(resourceGroups.get(1).getName(), "localization-eng");
     Assert.assertEquals(resourceGroups.get(1).getHardConcurrencyLimit(), 50);
     Assert.assertEquals(resourceGroups.get(1).getMaxQueued(), 70);
-    Assert.assertEquals(resourceGroups.get(1).isJmxExport(), true);
+    Assert.assertEquals(resourceGroups.get(1).getJmxExport(), Boolean.TRUE);
     Assert.assertEquals(resourceGroups.get(1).getSoftMemoryLimit(), "20%");
-    Assert.assertEquals(resourceGroups.get(1).getSoftConcurrencyLimit(), 20);
+    Assert.assertEquals(resourceGroups.get(1).getSoftConcurrencyLimit(), Integer.valueOf(20));
   }
 
   @Test(dependsOnMethods = {"testUpdateResourceGroup"})
   public void testDeleteResourceGroup() {
-    List<ResourceGroupsDetail> resourceGroups = resourceGroupManager.readResourceGroup();
+    List<ResourceGroupsDetail> resourceGroups = resourceGroupManager.readAllResourceGroups();
     Assert.assertEquals(resourceGroups.size(), 3);
 
     Assert.assertEquals(resourceGroups.get(0).getResourceGroupId(), 0L);
@@ -131,14 +130,14 @@ public class TestResourceGroupManager {
     Assert.assertEquals(resourceGroups.get(2).getResourceGroupId(), 3L);
 
     resourceGroupManager.deleteResourceGroup(resourceGroups.get(1).getResourceGroupId());
-    resourceGroups = resourceGroupManager.readResourceGroup();
+    resourceGroups = resourceGroupManager.readAllResourceGroups();
 
     Assert.assertEquals(resourceGroups.size(), 2);
     Assert.assertEquals(resourceGroups.get(0).getResourceGroupId(), 0L);
     Assert.assertEquals(resourceGroups.get(1).getResourceGroupId(), 3L);
 
     resourceGroupManager.deleteResourceGroup(resourceGroups.get(1).getResourceGroupId());
-    resourceGroups = resourceGroupManager.readResourceGroup();
+    resourceGroups = resourceGroupManager.readAllResourceGroups();
 
     Assert.assertEquals(resourceGroups.size(), 1);
     Assert.assertEquals(resourceGroups.get(0).getResourceGroupId(), 0L);
@@ -162,7 +161,7 @@ public class TestResourceGroupManager {
 
   @Test(dependsOnMethods = {"testCreateSelector"})
   public void testReadSelector() {
-    List<SelectorsDetail> selectors = resourceGroupManager.readSelector();
+    List<SelectorsDetail> selectors = resourceGroupManager.readAllSelectors();
 
     Assert.assertEquals(selectors.size(), 1);
     Assert.assertEquals(selectors.get(0).getResourceGroupId(), 0L);
@@ -187,7 +186,7 @@ public class TestResourceGroupManager {
     selector.setSelectorResourceEstimate("estimate_updated");
 
     SelectorsDetail updated = resourceGroupManager.updateSelector(selector);
-    List<SelectorsDetail> selectors = resourceGroupManager.readSelector();
+    List<SelectorsDetail> selectors = resourceGroupManager.readAllSelectors();
 
     Assert.assertEquals(selectors.size(), 1);
     Assert.assertEquals(updated, selectors.get(0));
@@ -195,11 +194,11 @@ public class TestResourceGroupManager {
 
   @Test(dependsOnMethods = {"testUpdateSelector"})
   public void testDeleteSelector() {
-    List<SelectorsDetail> selectors = resourceGroupManager.readSelector();
+    List<SelectorsDetail> selectors = resourceGroupManager.readAllSelectors();
     Assert.assertEquals(selectors.size(), 1);
     Assert.assertEquals(selectors.get(0).getResourceGroupId(), 0L);
     resourceGroupManager.deleteSelector(selectors.get(0).getResourceGroupId());
-    selectors = resourceGroupManager.readSelector();
+    selectors = resourceGroupManager.readAllSelectors();
 
     Assert.assertEquals(selectors.size(), 0);
   }
@@ -220,7 +219,6 @@ public class TestResourceGroupManager {
       invalidGlobalProperty.setValue("1h");
       resourceGroupManager.createGlobalProperty(invalidGlobalProperty);
     } catch (Exception ex) {
-      logger.info(ex.toString());
       Assert.assertTrue(ex.getCause() instanceof org.h2.jdbc.JdbcSQLException);
       Assert.assertTrue(ex.getCause().getMessage().startsWith("Check constraint violation:"));
     }
@@ -228,7 +226,7 @@ public class TestResourceGroupManager {
 
   @Test(dependsOnMethods = {"testCreateGlobalProperties"})
   public void testReadGlobalProperties() {
-    List<GlobalPropertiesDetail> globalProperties = resourceGroupManager.readGlobalProperty();
+    List<GlobalPropertiesDetail> globalProperties = resourceGroupManager.readAllGlobalProperties();
 
     Assert.assertEquals(globalProperties.size(), 1);
     Assert.assertEquals(globalProperties.get(0).getName(), "cpu_quota_period");
@@ -243,7 +241,7 @@ public class TestResourceGroupManager {
 
     GlobalPropertiesDetail updated =
         resourceGroupManager.updateGlobalProperty(globalPropertiesDetail);
-    List<GlobalPropertiesDetail> globalProperties = resourceGroupManager.readGlobalProperty();
+    List<GlobalPropertiesDetail> globalProperties = resourceGroupManager.readAllGlobalProperties();
 
     Assert.assertEquals(globalProperties.size(), 1);
     Assert.assertEquals(updated, globalProperties.get(0));
@@ -254,7 +252,6 @@ public class TestResourceGroupManager {
       invalidGlobalProperty.setValue("1h");
       resourceGroupManager.updateGlobalProperty(invalidGlobalProperty);
     } catch (Exception ex) {
-      logger.info(ex.toString());
       Assert.assertTrue(ex.getCause() instanceof org.h2.jdbc.JdbcSQLException);
       Assert.assertTrue(ex.getCause().getMessage().startsWith("Check constraint violation:"));
     }
@@ -285,6 +282,14 @@ public class TestResourceGroupManager {
     Assert.assertEquals(exactSelectorsDetails.get(0).getSource(), "@test@test_pipeline");
     Assert.assertEquals(exactSelectorsDetails.get(0).getEnvironment(), "test");
     Assert.assertEquals(exactSelectorsDetails.get(0).getQueryType(), "query_type");
+
+    ExactSelectorsDetail exactSelector =
+        resourceGroupManager.getExactMatchSourceSelector(exactSelectorsDetails.get(0));
+
+    Assert.assertEquals(exactSelector.getResourceGroupId(), "0");
+    Assert.assertEquals(exactSelector.getSource(), "@test@test_pipeline");
+    Assert.assertEquals(exactSelector.getEnvironment(), "test");
+    Assert.assertEquals(exactSelector.getQueryType(), "query_type");
   }
 
   @AfterClass(alwaysRun = true)

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.1</version>
+        <version>1.8.2</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
Currently, we specify resource groups via a config file but we are now transitioning to specifying via database through the implementation of a CRUD API. The purpose of this change is to improve the overall time used to update resource groups. Previously, redeployment was necessary every time we needed to make a change (big or small) to the resource groups.

First, I implemented the backend by creating dao files for each of these four tables (resource_groups, selectors, resource_groups_global_properties, exact_source_match_selectors), integrating them to the API file, and writing unit tests for all dao files. Next, I created separate CRUD APIs for each table in PrestoResource.java and tested them in the local Presto Gateway environment using CURL commands & Postman (specified in the README). 

In this PR, I decided to not include API calls to the Exact Source Match Selectors table, since this table does not seem to be used at Lyft as of now (the backend code I had for this table is written and/or commented out). 

Table Schemas: https://github.com/lyft/presto/blob/master/presto-resource-group-managers/src/test/java/io/prestosql/plugin/resourcegroups/db/H2ResourceGroupsDao.java

JIRA Descriptions:
Resource Groups: https://jira.lyft.net/browse/DATA-10162
Selectors: https://jira.lyft.net/browse/DATA-10164
Global Properties: https://jira.lyft.net/browse/DATA-10163
Exact Source Match Selectors: https://jira.lyft.net/browse/DATA-10165

The previous two PRs I made are https://github.com/lyft/presto-gateway/pull/112 and https://github.com/lyft/presto-gateway/pull/113.
