### PR TITLE
Updating Selector's Update and Delete Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,21 +207,36 @@ curl -X GET http://localhost:8080/presto/selector/read/{INSERT_ID_HERE}
 ```
 
 ### Update a selector
-Specify all columns in the body, which will overwrite properties for the selector with that specific resourceGroupId.
+To update a selector, the existing selector must be specified with all relevant fields under "current". The updated version of that selector is specified under "update", with all relevant fields included. If the selector under "current" does not exist, a new selector will be created with the details under "update". Both "current" and "update" must be included to update a selector. 
 ```$xslt
 curl -X POST http://localhost:8080/presto/selector/update \
- -d '{  "resourceGroupId": 1, \
-        "priority": 2, \
-        "userRegex": "selector_updated", \
+ -d '{  "current": {
+        "resourceGroupId": 1, \
+        "priority": 1, \
+        "userRegex": "selector1", \
         "sourceRegex": "resourcegroup1", \
         "queryType": "insert" \
-     }'
+        },
+        "update":  {
+            "resourceGroupId": 1, \
+            "priority": 2, \
+            "userRegex": "selector1_updated", \
+            "sourceRegex": "resourcegroup1", \
+            "queryType": null \
+        }
+}'
 ```
 
 ### Delete a selector
-To delete a selector, specify the corresponding resourceGroupId (type long).
+To delete a selector, specify all relevant fields in the body.
 ```$xslt
-curl -X POST http://localhost:8080/presto/selector/delete/{INSERT_ID_HERE}
+curl -X POST http://localhost:8080/presto/selector/delete/ \
+ -d '{  "resourceGroupId": 1, \
+        "priority": 2, \
+        "userRegex": "selector1_updated", \
+        "sourceRegex": "resourcegroup1", \
+        "queryType": null \
+     }'
 ```
 
 ### Add a global property

--- a/README.md
+++ b/README.md
@@ -211,11 +211,11 @@ To update a selector, the existing selector must be specified with all relevant 
 ```$xslt
 curl -X POST http://localhost:8080/presto/selector/update \
  -d '{  "current": {
-        "resourceGroupId": 1, \
-        "priority": 1, \
-        "userRegex": "selector1", \
-        "sourceRegex": "resourcegroup1", \
-        "queryType": "insert" \
+            "resourceGroupId": 1, \
+            "priority": 1, \
+            "userRegex": "selector1", \
+            "sourceRegex": "resourcegroup1", \
+            "queryType": "insert" \
         },
         "update":  {
             "resourceGroupId": 1, \
@@ -230,7 +230,7 @@ curl -X POST http://localhost:8080/presto/selector/update \
 ### Delete a selector
 To delete a selector, specify all relevant fields in the body.
 ```$xslt
-curl -X POST http://localhost:8080/presto/selector/delete/ \
+curl -X POST http://localhost:8080/presto/selector/delete \
  -d '{  "resourceGroupId": 1, \
         "priority": 2, \
         "userRegex": "selector1_updated", \

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
@@ -77,7 +77,7 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
 
   @Provides
   @Singleton
-  public ResourceGroupsManager getPrestoResourceManager() {
+  public ResourceGroupsManager getResourceGroupsManager() {
     return this.resourceGroupsManager;
   }
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/PrestoResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/PrestoResource.java
@@ -13,7 +13,6 @@ import com.lyft.data.gateway.ha.router.ResourceGroupsManager.SelectorsDetail;
 
 import java.io.IOException;
 import java.util.List;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -29,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Path("/presto")
 @Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class PrestoResource {
   @Inject private ResourceGroupsManager resourceGroupsManager;
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -129,9 +127,9 @@ public class PrestoResource {
     try {
       JsonNode selectors = OBJECT_MAPPER.readValue(jsonPayload, JsonNode.class);
       SelectorsDetail selector =
-          OBJECT_MAPPER.readValue(selectors.get("current").asText(), SelectorsDetail.class);
+          OBJECT_MAPPER.readValue(selectors.get("current").toString(), SelectorsDetail.class);
       SelectorsDetail newSelector =
-          OBJECT_MAPPER.readValue(selectors.get("update").asText(), SelectorsDetail.class);
+          OBJECT_MAPPER.readValue(selectors.get("update").toString(), SelectorsDetail.class);
 
       SelectorsDetail updatedSelector =
           this.resourceGroupsManager.updateSelector(selector, newSelector);

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/PrestoResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/PrestoResource.java
@@ -13,6 +13,7 @@ import com.lyft.data.gateway.ha.router.ResourceGroupsManager.SelectorsDetail;
 
 import java.io.IOException;
 import java.util.List;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -28,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Path("/presto")
 @Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class PrestoResource {
   @Inject private ResourceGroupsManager resourceGroupsManager;
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/PrestoResource.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/resource/PrestoResource.java
@@ -1,5 +1,6 @@
 package com.lyft.data.gateway.ha.resource;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
@@ -124,8 +125,14 @@ public class PrestoResource {
   @POST
   public Response updateSelector(String jsonPayload) {
     try {
-      SelectorsDetail selector = OBJECT_MAPPER.readValue(jsonPayload, SelectorsDetail.class);
-      SelectorsDetail updatedSelector = this.resourceGroupsManager.updateSelector(selector);
+      JsonNode selectors = OBJECT_MAPPER.readValue(jsonPayload, JsonNode.class);
+      SelectorsDetail selector =
+          OBJECT_MAPPER.readValue(selectors.get("current").asText(), SelectorsDetail.class);
+      SelectorsDetail newSelector =
+          OBJECT_MAPPER.readValue(selectors.get("update").asText(), SelectorsDetail.class);
+
+      SelectorsDetail updatedSelector =
+          this.resourceGroupsManager.updateSelector(selector, newSelector);
       return Response.ok(updatedSelector).build();
     } catch (IOException e) {
       log.error(e.getMessage(), e);
@@ -133,14 +140,18 @@ public class PrestoResource {
     }
   }
 
-  @Path("/selector/delete/{resourceGroupId}")
+  @Path("/selector/delete/")
   @POST
-  public Response deleteSelector(@PathParam("resourceGroupId") String resourceGroupIdStr) {
-    if (Strings.isNullOrEmpty(resourceGroupIdStr)) { // if query not specified, return all
+  public Response deleteSelector(String jsonPayload) {
+    if (Strings.isNullOrEmpty(jsonPayload)) {
       throw new WebApplicationException("EntryType can not be null");
     }
-    long resourceGroupId = Long.parseLong(resourceGroupIdStr);
-    resourceGroupsManager.deleteSelector(resourceGroupId);
+    try {
+      SelectorsDetail selector = OBJECT_MAPPER.readValue(jsonPayload, SelectorsDetail.class);
+      resourceGroupsManager.deleteSelector(selector);
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+    }
     return Response.ok().build();
   }
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaResourceGroupsManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaResourceGroupsManager.java
@@ -154,9 +154,10 @@ public class HaResourceGroupsManager implements ResourceGroupsManager {
   }
 
   /**
-   * Updates an existing resource group with new values.
+   * Updates a selector given the specified selector and its updated version.
    *
    * @param selector
+   * @param updatedSelector
    * @return
    */
   @Override
@@ -188,7 +189,7 @@ public class HaResourceGroupsManager implements ResourceGroupsManager {
   }
 
   /**
-   * Search for selector by its resourceGroupId and delete it.
+   * Search for selector by its exact properties and delete it.
    *
    * @param selector
    */

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaResourceGroupsManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaResourceGroupsManager.java
@@ -164,19 +164,21 @@ public class HaResourceGroupsManager implements ResourceGroupsManager {
   public SelectorsDetail updateSelector(SelectorsDetail selector, SelectorsDetail updatedSelector) {
     try {
       connectionManager.open();
-      Selectors model =
-          Selectors.findFirst(
-              "resource_group_id = ? and priority = ? "
-                  + "and user_regex = ? and source_regex = ? "
-                  + "and query_type = ? and client_tags = ? "
-                  + "and selector_resource_estimate = ?",
-              selector.getResourceGroupId(),
-              selector.getPriority(),
-              selector.getUserRegex(),
-              selector.getSourceRegex(),
-              selector.getQueryType(),
-              selector.getClientTags(),
-              selector.getSelectorResourceEstimate());
+      String query =
+          String.format(
+              "resource_group_id %s and priority %s "
+                  + "and user_regex %s and source_regex %s "
+                  + "and query_type %s and client_tags %s "
+                  + "and selector_resource_estimate %s",
+              getMatchingString(selector.getResourceGroupId()),
+              getMatchingString(selector.getPriority()),
+              getMatchingString(selector.getUserRegex()),
+              getMatchingString(selector.getSourceRegex()),
+              getMatchingString(selector.getQueryType()),
+              getMatchingString(selector.getClientTags()),
+              getMatchingString(selector.getSelectorResourceEstimate()));
+      Selectors model = Selectors.findFirst(query);
+
       if (model == null) {
         Selectors.create(new Selectors(), updatedSelector);
       } else {
@@ -197,18 +199,21 @@ public class HaResourceGroupsManager implements ResourceGroupsManager {
   public void deleteSelector(SelectorsDetail selector) {
     try {
       connectionManager.open();
-      Selectors.delete(
-          "resource_group_id = ? and priority = ? "
-              + "and user_regex = ? and source_regex = ? "
-              + "and query_type = ? and client_tags = ? "
-              + "and selector_resource_estimate = ?",
-          selector.getResourceGroupId(),
-          selector.getPriority(),
-          selector.getUserRegex(),
-          selector.getSourceRegex(),
-          selector.getQueryType(),
-          selector.getClientTags(),
-          selector.getSelectorResourceEstimate());
+      String query =
+          String.format(
+              "resource_group_id %s and priority %s "
+                  + "and user_regex %s and source_regex %s "
+                  + "and query_type %s and client_tags %s "
+                  + "and selector_resource_estimate %s",
+              getMatchingString(selector.getResourceGroupId()),
+              getMatchingString(selector.getPriority()),
+              getMatchingString(selector.getUserRegex()),
+              getMatchingString(selector.getSourceRegex()),
+              getMatchingString(selector.getQueryType()),
+              getMatchingString(selector.getClientTags()),
+              getMatchingString(selector.getSelectorResourceEstimate()));
+      Selectors.delete(query);
+
     } finally {
       connectionManager.close();
     }
@@ -357,5 +362,14 @@ public class HaResourceGroupsManager implements ResourceGroupsManager {
       connectionManager.close();
     }
     return exactSelectorDetail;
+  }
+
+  public String getMatchingString(Object detail) {
+    if (detail == null) {
+      return "IS NULL";
+    } else if (detail.getClass().equals(String.class)) {
+      return "= '" + detail + "'";
+    }
+    return "= " + detail;
   }
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaResourceGroupsManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/HaResourceGroupsManager.java
@@ -160,32 +160,54 @@ public class HaResourceGroupsManager implements ResourceGroupsManager {
    * @return
    */
   @Override
-  public SelectorsDetail updateSelector(SelectorsDetail selector) {
+  public SelectorsDetail updateSelector(SelectorsDetail selector, SelectorsDetail updatedSelector) {
     try {
       connectionManager.open();
-      Selectors model = Selectors.findFirst("resource_group_id = ?", selector.getResourceGroupId());
-
+      Selectors model =
+          Selectors.findFirst(
+              "resource_group_id = ? and priority = ? "
+                  + "and user_regex = ? and source_regex = ? "
+                  + "and query_type = ? and client_tags = ? "
+                  + "and selector_resource_estimate = ?",
+              selector.getResourceGroupId(),
+              selector.getPriority(),
+              selector.getUserRegex(),
+              selector.getSourceRegex(),
+              selector.getQueryType(),
+              selector.getClientTags(),
+              selector.getSelectorResourceEstimate());
       if (model == null) {
-        Selectors.create(new Selectors(), selector);
+        Selectors.create(new Selectors(), updatedSelector);
       } else {
-        Selectors.update(model, selector);
+        Selectors.update(model, updatedSelector);
       }
     } finally {
       connectionManager.close();
     }
-    return selector;
+    return updatedSelector;
   }
 
   /**
    * Search for selector by its resourceGroupId and delete it.
    *
-   * @param resourceGroupId
+   * @param selector
    */
   @Override
-  public void deleteSelector(long resourceGroupId) {
+  public void deleteSelector(SelectorsDetail selector) {
     try {
       connectionManager.open();
-      Selectors.delete("resource_group_id = ?", resourceGroupId);
+      Selectors.delete(
+          "resource_group_id = ? and priority = ? "
+              + "and user_regex = ? and source_regex = ? "
+              + "and query_type = ? and client_tags = ? "
+              + "and selector_resource_estimate = ?",
+          selector.getResourceGroupId(),
+          selector.getPriority(),
+          selector.getUserRegex(),
+          selector.getSourceRegex(),
+          selector.getQueryType(),
+          selector.getClientTags(),
+          selector.getSelectorResourceEstimate());
     } finally {
       connectionManager.close();
     }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/ResourceGroupsManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/ResourceGroupsManager.java
@@ -24,9 +24,9 @@ public interface ResourceGroupsManager {
 
   List<SelectorsDetail> readSelector(long resourceGroupId);
 
-  SelectorsDetail updateSelector(SelectorsDetail selector);
+  SelectorsDetail updateSelector(SelectorsDetail selector, SelectorsDetail updatedSelector);
 
-  void deleteSelector(long resourceGroupId);
+  void deleteSelector(SelectorsDetail selector);
 
   GlobalPropertiesDetail createGlobalProperty(GlobalPropertiesDetail globalPropertyDetail);
 


### PR DESCRIPTION
Currently, selectors are updated and deleted solely based off their resourceGroupId. This functionality is not representative of the actual relationship between selectors and resource groups, which is many to one (there can be multiple selectors with the same resource group id). With this change, the current selector's json must also be specified in addition to the updated selector's json - if the current selector's json does not exist, a new selector is created.

Relevant PRs: https://github.com/lyft/presto-gateway/pull/114