### PR TITLE
Setting forwarded host correctly

### DIFF
--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.4</version>
+        <version>1.8.5</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.4</version>
+        <version>1.8.5</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -20,10 +20,8 @@ import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.HttpMethod;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.util.Callback;
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -20,8 +20,10 @@ import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.HttpMethod;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.client.api.Request;
+
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.util.Callback;
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -83,26 +83,9 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     }
 
     if (isPathWhiteListed(request.getRequestURI())) {
-      // Set the Host Header to proxy target
       setForwardedHostHeaderOnProxyRequest(request, proxyRequest);
-      logRequestHeaders("After Setting Host Header on proxyRequest", proxyRequest);
     }
 
-  }
-
-  private void logRequestHeaders(String msg, Request request) {
-    HttpFields httpFields = request.getHeaders();
-    StringBuilder sb = new StringBuilder();
-    if (httpFields != null) {
-      Enumeration<String> headerNameFields = httpFields.getFieldNames();
-      while (headerNameFields.hasMoreElements()) {
-        String headerName = headerNameFields.nextElement();
-        String value = httpFields.get(headerName);
-        sb.append(headerName).append(":").append(value).append(",");
-      }
-    }
-    log.debug("[{}] For Request [{}], headers are [{}]", msg, request.getURI().toString(),
-        sb.toString());
   }
 
   private boolean isPathWhiteListed(String path) {
@@ -282,8 +265,8 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     super.postConnectionHook(request, response, buffer, offset, length, callback);
   }
 
-  private void setForwardedHostHeaderOnProxyRequest(HttpServletRequest request,
-                                                    Request proxyRequest) {
+  static void setForwardedHostHeaderOnProxyRequest(HttpServletRequest request,
+                                                   Request proxyRequest) {
     if (request.getHeader(PROXY_TARGET_HEADER) != null) {
       try {
         URI backendUri = new URI(request.getHeader(PROXY_TARGET_HEADER));

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
@@ -68,7 +68,7 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
       routerProxyConfig.setSsl(routerConfiguration.isSsl());
       routerProxyConfig.setKeystorePath(routerConfiguration.getKeystorePath());
       routerProxyConfig.setKeystorePass(routerConfiguration.getKeystorePass());
-
+      routerProxyConfig.setPreserveHost("false");
       ProxyHandler proxyHandler = getProxyHandler();
       gateway = new ProxyServer(routerProxyConfig, proxyHandler);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.8.4</version>
+    <version>1.8.5</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.4</version>
+        <version>1.8.5</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
Presto Uses "X-Forwarded-Host" to determine the nextURi & InfoURI. These headers are set correctly on the outgoing Proxy request as we are using ProxyServlet.Transparent . Reference : https://github.com/lyft/presto-gateway/blob/master/proxyserver/src/main/java/com/lyft/data/proxyserver/ProxyServletImpl.java 

 This PR explicitly sets the Host Header to the host name of the backend presto cluster vs preserving the Host of the gateway itself. This ensures that we dont run into 400 Bad request Issues if there is an LB fronting the backend Presto cluster. 