### PR TITLE
Add support for Trino

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -35,8 +36,10 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
   public static final String V1_INFO_PATH = "/v1/info";
   public static final String UI_API_STATS_PATH = "/ui/api/stats";
   public static final String PRESTO_UI_PATH = "/ui";
-  public static final String USER_HEADER = "X-Presto-User";
-  public static final String SOURCE_HEADER = "X-Presto-Source";
+  public static final String USER_HEADER = "X-Trino-User";
+  public static final String ALTERNATE_USER_HEADER = "X-Presto-User";
+  public static final String SOURCE_HEADER = "X-Trino-Source";
+  public static final String ALTERNATE_SOURCE_HEADER = "X-Presto-Source";
   public static final String HOST_HEADER = "Host";
   private static final int QUERY_TEXT_LENGTH_FOR_HISTORY = 200;
   private static final Pattern QUERY_ID_PATTERN = Pattern.compile(".*[/=?](\\d+_\\d+_\\d+_\\w+).*");
@@ -293,8 +296,10 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     QueryHistoryManager.QueryDetail queryDetail = new QueryHistoryManager.QueryDetail();
     queryDetail.setBackendUrl(request.getHeader(PROXY_TARGET_HEADER));
     queryDetail.setCaptureTime(System.currentTimeMillis());
-    queryDetail.setUser(request.getHeader(USER_HEADER));
-    queryDetail.setSource(request.getHeader(SOURCE_HEADER));
+    queryDetail.setUser(Optional.ofNullable(request.getHeader(USER_HEADER))
+            .orElse(request.getHeader(ALTERNATE_USER_HEADER)));
+    queryDetail.setSource(Optional.ofNullable(request.getHeader(SOURCE_HEADER))
+            .orElse(request.getHeader(ALTERNATE_SOURCE_HEADER)));
     String queryText = CharStreams.toString(request.getReader());
     queryDetail.setQueryText(
         queryText.length() > QUERY_TEXT_LENGTH_FOR_HISTORY

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
@@ -1,17 +1,20 @@
 package com.lyft.data.gateway.ha.router;
 
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 
 /** RoutingGroupSelector provides a way to match an HTTP request to a Gateway routing group. */
 public interface RoutingGroupSelector {
-  String ROUTING_GROUP_HEADER = "X-Presto-Routing-Group";
+  String ROUTING_GROUP_HEADER = "X-Trino-Routing-Group";
+  String ALTERNATE_ROUTING_GROUP_HEADER = "X-Presto-Routing-Group";
 
   /**
-   * Routing group selector that relies on the X-Presto-Routing-Group header to determine the right
-   * routing group.
+   * Routing group selector that relies on the X-Trino-Routing-Group or X-Presto-Routing-Group
+   * header to determine the right routing group.
    */
   static RoutingGroupSelector byRoutingGroupHeader() {
-    return request -> request.getHeader(ROUTING_GROUP_HEADER);
+    return request -> Optional.ofNullable(request.getHeader(ROUTING_GROUP_HEADER))
+            .orElse(request.getHeader(ALTERNATE_ROUTING_GROUP_HEADER));
   }
 
   /**

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/TestGatewayHaMulipleBackend.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/TestGatewayHaMulipleBackend.java
@@ -77,6 +77,17 @@ public class TestGatewayHaMulipleBackend {
             .build();
     Response response3 = httpClient.newCall(request3).execute();
     Assert.assertEquals(response3.body().string(), EXPECTED_RESPONSE1);
+
+    // When X-Trino-Routing-Group is set in header, query should be routed to cluster under the
+    // routing group
+    Request request4 =
+            new Request.Builder()
+                    .url("http://localhost:" + routerPort + "/v1/statement")
+                    .post(requestBody)
+                    .addHeader("X-Trino-Routing-Group", "scheduled")
+                    .build();
+    Response response4 = httpClient.newCall(request4).execute();
+    Assert.assertEquals(response4.body().string(), EXPECTED_RESPONSE2);
   }
 
   @AfterClass(alwaysRun = true)


### PR DESCRIPTION
Trino uses `X-Trino` headers instead of `X-Presto` headers. Gateway uses `X-Presto-User` and `X-Presto-Source` to determine the user and source of query. Gateway would continue to work, however, these important metrics would not get recorded, for any query coming from a Trino client.

Check for either `X-Trino-User` or `X-Presto-User` is done on each query request. Similar check is done for `X-Presto-Source` and `X-Trino-Source`. Client libraries can specify `X-Trino-Routing-Group` instead of `X-Presto-Routing-Group`, for uniformity.

Fixes #134.