### PR TITLE
Add routing rules engine feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ condition: "request.getHeader(\"X-Trino-Client-Tags\") contains \"label=foo\""
 If no rules match, then request is routed to adhoc.
 
 ### Execution of Rules
-All rules whose conditions are satisfied will fire. For example, in the two example rules given above, a query with source `airflow` and label `special`
+All rules whose conditions are satisfied will fire. For example, in the "airflow" and "airflow special" example rules given above, a query with source `airflow` and label `special`
 will satisfy both rules. The `routingGroup` is set to `etl` and then to `etl-special` because of the order in which the rules of defined.
 If we swap the order of the rules, then we would possibly get `etl` instead, which is undesirable.
 

--- a/README.md
+++ b/README.md
@@ -483,7 +483,8 @@ actions:
 ```
 
 ### Enabling routing rules engine
-To enable routing rules engine, add the following lines to `gateway-ha-config.yml`.
+To enable routing rules engine, find the following lines in `gateway-ha-config.yml`.
+Set `rulesEngineEnabled` to True and `rulesConfigPath` to the path to your rules config file.
 ```
 routingRules:
   rulesEngineEnabled: true

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ If no rules match, then request is routed to adhoc.
 
 ### Execution of Rules
 All rules whose conditions are satisfied will fire. For example, in the two example rules given above, a query with source `airflow` and label `special`
-will satisfy both rules. The `routingGroup` is set to `etl` and then to `etl-critical` because of the order in which the rules of defined.
+will satisfy both rules. The `routingGroup` is set to `etl` and then to `etl-special` because of the order in which the rules of defined.
 If we swap the order of the rules, then we would possibly get `etl` instead, which is undesirable.
 
 One could solve this by writing the rules such that they're atomic (any query will match exactly one rule). For example we can change the first rule to
@@ -373,7 +373,7 @@ actions:
   - "result.put(\"routingGroup\", \"etl-special\")"
 ```
 Note that both rules will still fire. The difference is that we've guaranteed that the first rule (priority 0) is fired before the second rule (priority 1). Thus `routingGroup`
-is set to `etl` and then to `etl-critical`, so the `routingGroup` will always be `etl-critical` in the end.
+is set to `etl` and then to `etl-special`, so the `routingGroup` will always be `etl-special` in the end.
 
 Above, the more specific rules have less priority since we want them to be the last to set `routingGroup`. This is a little counterintuitive.
 To further control the execution of rules, for example to have only one rule fire, we can use composite rules.

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ To gracefully shutdown a single worker process, see [this](https://trino.io/docs
 
 ## Routing Rules Engine
 By default, presto-gateway reads the `X-Trino-Routing-Group` request header to route requests.
-If this header is not specified, requests are sent to adhoc.
+If this header is not specified, requests are sent to default routing group (adhoc).
 
 The routing rules engine feature enables you to write custom logic to route requests based on the request info such as any of the [request headers](https://trino.io/docs/current/develop/client-protocol.html#client-request-headers).
 Routing rules are separated from presto-gateway application code to a configuration file, allowing for dynamic rule changes.

--- a/README.md
+++ b/README.md
@@ -295,6 +295,170 @@ To graceful shutdown a Presto cluster without query losses, the steps are:
 
 To gracefully shutdown a single worker process, see [this](https://trino.io/docs/current/admin/graceful-shutdown.html) for the operations.
 
+## Routing Rules Engine
+By default, presto-gateway reads the `X-Trino-Routing-Group` request header to route requests.
+If this header is not specified, requests are sent to adhoc.
+
+The routing rules engine feature enables you to write custom logic to route requests based on the request info such as any of the [request headers](https://trino.io/docs/current/develop/client-protocol.html#client-request-headers).
+Routing rules are separated from presto-gateway application code to a configuration file, allowing for dynamic rule changes.
+
+### Defining your routing rules
+To express and fire routing rules, we use the [easy-rules](https://github.com/j-easy/easy-rules) engine. These rules should be stored in a YAML file.
+Rules consist of a name, description, condition, and list of actions. If the condition of a particular rule evaluates to true, its actions are fired.
+```yaml
+---
+name: "airflow"
+description: "if query from airflow, route to etl group"
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
+actions:
+  - "facts.put(\"routingGroup\", \"etl\")"
+---
+name: "airflow special"
+description: "if query from airflow with special label, route to etl-special group"
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""
+actions:
+  - "facts.put(\"routingGroup\", \"etl-special\")"
+```
+In the condition, you can access the methods of a [HttpServletRequest](https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html) object called `request`.
+There should be at least one action of the form `facts.put(\"routingGroup\", \"foo\")` which says that if a request satisfies the condition, it should be routed to `foo`.
+
+The condition and actions are written in [MVEL](http://mvel.documentnode.com/), an expression language with Java-like syntax.
+In most cases, users can write their conditions/actions in Java syntax and expect it to work. There are some MVEL-specific operators that could be useful though.
+For example, instead of doing a null-check before accessing the `String.contains` method like this:
+```yaml
+condition: "request.getHeader(\"X-Trino-Client-Tags\") != null && request.getHeader(\"X-Trino-Client-Tags\").contains(\"label=foo\")"
+```
+You can use the `contains` operator
+```yaml
+condition: "request.getHeader(\"X-Trino-Client-Tags\") contains \"label=foo\""
+```
+If no rules match, then request is routed to adhoc.
+
+### Execution of Rules
+All rules whose conditions are satisfied will fire. For example, in the two example rules given above, a query with source `airflow` and label `special`
+will satisfy both rules. The `routingGroup` is set to `etl` and then to `etl-critical` because of the order in which the rules of defined.
+If we swap the order of the rules, then we would get `etl` instead, which is undesirable.
+
+One could solve this by writing the rules such that they're atomic (any query will match exactly one rule). For example we can change the first rule to
+```yaml
+---
+name: "airflow"
+description: "if query from airflow, route to etl group"
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\") == null"
+actions:
+  - "facts.put(\"routingGroup\", \"etl\")"
+---
+```
+
+This could be hard to maintain as we add more rules. To have better control over the execution of rules, we could use rule priorities and composite rules.
+
+#### Rule Priority
+We can assign an integer value `priority` to a rule. The lower this integer is, the earlier it will fire.
+If the priority is not specified, the priority is defaulted to INT\_MAX.
+We can add priorities to our airflow and airflow special rule like so:
+```yaml
+---
+name: "airflow"
+description: "if query from airflow, route to etl group"
+priority: 0
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
+actions:
+  - "facts.put(\"routingGroup\", \"etl\")"
+---
+name: "airflow special"
+description: "if query from airflow with special label, route to etl-special group"
+priority: 1
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""
+actions:
+  - "facts.put(\"routingGroup\", \"etl-special\")"
+```
+Note that both rules will still fire. The difference is that we've guaranteed that the first rule (priority 0) is fired before the second rule (priority 1). Thus `routingGroup`
+is set to `etl` and then to `etl-critical`, so the `routingGroup` will always be `etl-critical` in the end.
+
+Above, the more specific rules have less priority since we want them to be the last to set `routingGroup`. This is a little counterintuitive.
+To further control the execution of rules, for example to have only one rule fire, we can use composite rules.
+
+##### Composite Rules
+First, please refer to easy-rule composite rules docs: https://github.com/j-easy/easy-rules/wiki/defining-rules#composite-rules
+
+Above, we saw how to control the order of rule execution using priorities. In addition to this, we could have only the first rule matched to be
+fired (the highest priority one) and the rest ignored. We can use `ActivationRuleGroup` to achieve this.
+```yaml
+---
+name: "airflow rule group"
+description: "routing rules for query from airflow"
+compositeRuleType: "ActivationRuleGroup"
+composingRules:
+  - name: "airflow special"
+    description: "if query from airflow with special label, route to etl-special group"
+    priority: 0
+    condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""
+    actions:
+      - "facts.put(\"routingGroup\", \"etl-special\")"
+  - name: "airflow"
+    description: "if query from airflow, route to etl group"
+    priority: 1
+    condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
+    actions:
+      - "facts.put(\"routingGroup\", \"etl\")"
+```
+Note that the priorities have switched. The more specific rule has a higher priority, since we want it to be fired first.
+A query coming from airflow with special label is matched to the "airflow special" rule first, since it's higher priority,
+and the second rule is ignored. A query coming from airflow with no labels does not match the first rule, and is then tested and matched to the second rule.
+
+We can also use `ConditionalRuleGroup` and `ActivationRuleGroup` to implement an if/else workflow.
+The following logic in pseudocode:
+```
+if source == "airflow":
+  if clientTags["label"] == "foo":
+    return "etl-foo"
+  else if clientTags["label"] = "bar":
+    return "etl-bar"
+  else
+    return "etl"
+```
+Can be implemented with these rules:
+```yaml
+name: "airflow rule group"
+description: "routing rules for query from airflow"
+compositeRuleType: "ConditionalRuleGroup"
+composingRules:
+  - name: "main condition"
+    description: "source is airflow"
+    priority: 0 # rule with the highest priority acts as main condition
+    condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
+    actions:
+      - ""
+  - name: "airflow subrules"
+    compositeRuleType: "ActivationRuleGroup" # use ActivationRuleGroup to simulate if/else
+    composingRules:
+      - name: "label foo"
+        description: "label client tag is foo"
+        priority: 0
+        condition: "request.getHeader(\"X-Trino-Client-Tags\") contains \"label=foo\""
+        actions:
+          - "facts.put(\"routingGroup\", \"etl-foo\")"
+      - name: "label bar"
+        description: "label client tag is bar"
+        priority: 0
+        condition: "request.getHeader(\"X-Trino-Client-Tags\") contains \"label=bar\""
+        actions:
+          - "facts.put(\"routingGroup\", \"etl-bar\")"
+      - name: "airflow default"
+        description: "airflow queries default to etl"
+        condition: "true"
+        actions:
+          - "facts.put(\"routingGroup\", \"etl\")"
+```
+
+### Enabling routing rules engine
+To enable routing rules engine, add the following lines to `gateway-ha-config.yml`.
+```
+routingRules:
+  rulesEngineEnabled: true
+  rulesConfigPath: "src/test/resources/rules/routing_rules.yml" # replace with path to your rules config file
+```
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -349,7 +349,6 @@ actions:
   - "facts.put(\"routingGroup\", \"etl\")"
 ---
 ```
-
 This could be hard to maintain as we add more rules. To have better control over the execution of rules, we could use rule priorities and composite rules.
 
 #### Rule Priority

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ If no rules match, then request is routed to adhoc.
 ### Execution of Rules
 All rules whose conditions are satisfied will fire. For example, in the two example rules given above, a query with source `airflow` and label `special`
 will satisfy both rules. The `routingGroup` is set to `etl` and then to `etl-critical` because of the order in which the rules of defined.
-If we swap the order of the rules, then we would get `etl` instead, which is undesirable.
+If we swap the order of the rules, then we would possibly get `etl` instead, which is undesirable.
 
 One could solve this by writing the rules such that they're atomic (any query will match exactly one rule). For example we can change the first rule to
 ```yaml

--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.6</version>
+        <version>1.8.7</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/gateway-ha-config.yml
+++ b/gateway-ha/gateway-ha-config.yml
@@ -1,3 +1,7 @@
+routingRules:
+  rulesEngineEnabled: true
+  rulesConfigPath: "src/test/resources/rules/routing_rules.yml"
+
 requestRouter:
   port: 8080
   name: prestoRouter

--- a/gateway-ha/gateway-ha-config.yml
+++ b/gateway-ha/gateway-ha-config.yml
@@ -1,7 +1,3 @@
-routingRules:
-  rulesEngineEnabled: true
-  rulesConfigPath: "src/test/resources/rules/routing_rules.yml"
-
 requestRouter:
   port: 8080
   name: prestoRouter

--- a/gateway-ha/gateway-ha-config.yml
+++ b/gateway-ha/gateway-ha-config.yml
@@ -1,3 +1,7 @@
+routingRules:
+  rulesEngineEnabled: False
+  # rulesConfigPath: "src/main/resources/rules/routing_rules.yml"
+
 requestRouter:
   port: 8080
   name: prestoRouter

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.6</version>
+        <version>1.8.7</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -25,6 +25,7 @@
         <dropwizard.version>1.3.8</dropwizard.version>
         <guice.version>4.1.0</guice.version>
         <guava.version>23.0</guava.version>
+        <jeasy.version>4.1.0</jeasy.version>
         <reflections.version>0.9.10</reflections.version>
         <ehcache.version>3.8.1</ehcache.version>
         <activejdbc.version>2.3</activejdbc.version>
@@ -37,17 +38,17 @@
         <dependency>
             <groupId>org.jeasy</groupId>
             <artifactId>easy-rules-core</artifactId>
-            <version>4.1.0</version>
+            <version>${jeasy.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jeasy</groupId>
             <artifactId>easy-rules-mvel</artifactId>
-            <version>4.1.0</version>
+            <version>${jeasy.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jeasy</groupId>
             <artifactId>easy-rules-support</artifactId>
-            <version>4.1.0</version>
+            <version>${jeasy.version}</version>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -35,6 +35,26 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jeasy</groupId>
+            <artifactId>easy-rules-core</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jeasy</groupId>
+            <artifactId>easy-rules-mvel</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jeasy</groupId>
+            <artifactId>easy-rules-support</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+          <version>2.10.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.lyft.data</groupId>
             <artifactId>baseapp</artifactId>
             <version>${project.parent.version}</version>

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/HaGatewayConfiguration.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/HaGatewayConfiguration.java
@@ -11,4 +11,5 @@ public class HaGatewayConfiguration extends AppConfiguration {
   private NotifierConfiguration notifier;
   private DataStoreConfiguration dataStore;
   private MonitorConfiguration monitor = new MonitorConfiguration();
+  private RoutingRulesConfiguration routingRules = new RoutingRulesConfiguration();
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RoutingRulesConfiguration.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RoutingRulesConfiguration.java
@@ -6,5 +6,4 @@ import lombok.Data;
 public class RoutingRulesConfiguration {
   private boolean rulesEngineEnabled;
   private String rulesConfigPath;
-  // private String rulesConfigPath = "localhost";
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RoutingRulesConfiguration.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/config/RoutingRulesConfiguration.java
@@ -1,0 +1,10 @@
+package com.lyft.data.gateway.ha.config;
+
+import lombok.Data;
+
+@Data
+public class RoutingRulesConfiguration {
+  private boolean rulesEngineEnabled;
+  private String rulesConfigPath;
+  // private String rulesConfigPath = "localhost";
+}

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
@@ -46,9 +46,8 @@ public interface RoutingGroupSelector {
         rulesEngine.fire(rules, facts);
         return facts.get("routingGroup");
       } catch (Exception e) {
-        Logger.log.error(
-            "Error opening rules configuration file %s."
-            + "Using routing group header as default..".format(rulesConfigPath));
+        Logger.log.error("Error opening rules configuration file,"
+            + " using routing group header as default.", e);
         return Optional.ofNullable(request.getHeader(ROUTING_GROUP_HEADER))
           .orElse(request.getHeader(ALTERNATE_ROUTING_GROUP_HEADER));
       }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
@@ -1,6 +1,7 @@
 package com.lyft.data.gateway.ha.router;
 
 import java.io.FileReader;
+import java.util.HashMap;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -41,10 +42,11 @@ public interface RoutingGroupSelector {
         Rules rules = ruleFactory.createRules(
             new FileReader(rulesConfigPath));
         Facts facts = new Facts();
+        HashMap<String, String> result = new HashMap<String, String>();
         facts.put("request", request);
-        facts.put("facts", facts);
+        facts.put("result", result);
         rulesEngine.fire(rules, facts);
-        return facts.get("routingGroup");
+        return result.get("routingGroup");
       } catch (Exception e) {
         Logger.log.error("Error opening rules configuration file,"
             + " using routing group header as default.", e);

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
@@ -3,6 +3,7 @@ package com.lyft.data.gateway.ha.router;
 import java.io.FileReader;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.jeasy.rules.api.Facts;
 import org.jeasy.rules.api.Rules;
 import org.jeasy.rules.api.RulesEngine;
@@ -14,6 +15,9 @@ import org.jeasy.rules.support.reader.YamlRuleDefinitionReader;
 public interface RoutingGroupSelector {
   String ROUTING_GROUP_HEADER = "X-Trino-Routing-Group";
   String ALTERNATE_ROUTING_GROUP_HEADER = "X-Presto-Routing-Group";
+
+  @Slf4j
+  final class Logger {}
 
   /**
    * Routing group selector that relies on the X-Trino-Routing-Group or X-Presto-Routing-Group
@@ -42,8 +46,7 @@ public interface RoutingGroupSelector {
         rulesEngine.fire(rules, facts);
         return facts.get("routingGroup");
       } catch (Exception e) {
-        // TODO: log
-        System.out.println(
+        Logger.log.error(
             "Error opening rules configuration file %s."
             + "Using routing group header as default..".format(rulesConfigPath));
         return Optional.ofNullable(request.getHeader(ROUTING_GROUP_HEADER))

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
@@ -92,7 +92,7 @@ public class TestRoutingGroupSelector {
         + "description: \"if query from airflow, route to etl group\"\n"
         + "condition: \"request.getHeader(\\\"X-Trino-Source\\\") == \\\"airflow\\\"\"\n"
         + "actions:\n"
-        + "  - \"facts.put(\\\"routingGroup\\\", \\\"etl\\\")\"");
+        + "  - \"result.put(\\\"routingGroup\\\", \\\"etl\\\")\"");
     fw.close();
 
     RoutingGroupSelector routingGroupSelector =
@@ -111,7 +111,7 @@ public class TestRoutingGroupSelector {
         + "description: \"if query from airflow, route to etl group\"\n"
         + "condition: \"request.getHeader(\\\"X-Trino-Source\\\") == \\\"airflow\\\"\"\n"
         + "actions:\n"
-        + "  - \"facts.put(\\\"routingGroup\\\", \\\"etl2\\\")\""); // change from etl to etl2
+        + "  - \"result.put(\\\"routingGroup\\\", \\\"etl2\\\")\""); // change from etl to etl2
     fw.close();
 
     when(mockRequest.getHeader(TRINO_SOURCE_HEADER)).thenReturn("airflow");

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
@@ -4,7 +4,10 @@ import static com.lyft.data.gateway.ha.router.RoutingGroupSelector.ROUTING_GROUP
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.io.FileReader;
+import java.io.FileWriter;
+import java.util.Scanner;
 import javax.servlet.http.HttpServletRequest;
 import org.jeasy.rules.api.Rule;
 import org.jeasy.rules.api.Rules;
@@ -84,19 +87,7 @@ public class TestRoutingGroupSelector {
         routingGroupSelector.findRoutingGroup(mockRequest), "etl-special");
   }
 
-
-  public void testByRoutingRulesEngineFileNotFound() {
-    String rulesConfigPath = null;
-    RoutingGroupSelector routingGroupSelector =
-        RoutingGroupSelector.byRoutingRulesEngine(rulesConfigPath);
-
-    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
-
-    when(mockRequest.getHeader(ROUTING_GROUP_HEADER)).thenReturn("batch_backend");
-    Assert.assertEquals(
-        RoutingGroupSelector.byRoutingGroupHeader().findRoutingGroup(mockRequest), "batch_backend");
-  }
-
   public void testByRoutingRulesEngineFileChange() {
   }
+
 }

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
@@ -61,6 +61,20 @@ public class TestRoutingGroupSelector {
         routingGroupSelector.findRoutingGroup(mockRequest), "etl-special");
   }
 
+  public void testByRoutingRulesEngineNoMatch() {
+    String rulesConfigPath = "src/test/resources/rules/routing_rules.yml";
+    RoutingGroupSelector routingGroupSelector =
+        RoutingGroupSelector.byRoutingRulesEngine(rulesConfigPath);
+
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    // even though special label is present, query is not from airflow.
+    // should return no match
+    when(mockRequest.getHeader(TRINO_CLIENT_TAGS_HEADER)).thenReturn(
+        "email=test@example.com,label=special");
+    Assert.assertEquals(
+        routingGroupSelector.findRoutingGroup(mockRequest), null);
+  }
+
   public void testByRoutingRulesEngineCompositeRules() {
     String rulesConfigPath = "src/test/resources/rules/routing_rules_composite.yml";
     RoutingGroupSelector routingGroupSelector =
@@ -85,6 +99,20 @@ public class TestRoutingGroupSelector {
         "email=test@example.com,label=special");
     Assert.assertEquals(
         routingGroupSelector.findRoutingGroup(mockRequest), "etl-special");
+  }
+
+  public void testByRoutingRulesEngineCompositeRulesNoMatch() {
+    String rulesConfigPath = "src/test/resources/rules/routing_rules_composite.yml";
+    RoutingGroupSelector routingGroupSelector =
+        RoutingGroupSelector.byRoutingRulesEngine(rulesConfigPath);
+
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    // even though special label is present, query is not from airflow.
+    // should return no match
+    when(mockRequest.getHeader(TRINO_CLIENT_TAGS_HEADER)).thenReturn(
+        "email=test@example.com,label=special");
+    Assert.assertEquals(
+        routingGroupSelector.findRoutingGroup(mockRequest), null);
   }
 
   public void testByRoutingRulesEngineFileChange() {

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
@@ -4,12 +4,21 @@ import static com.lyft.data.gateway.ha.router.RoutingGroupSelector.ROUTING_GROUP
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.FileReader;
 import javax.servlet.http.HttpServletRequest;
+import org.jeasy.rules.api.Rule;
+import org.jeasy.rules.api.Rules;
+import org.jeasy.rules.core.RuleBuilder;
+import org.jeasy.rules.mvel.MVELRuleFactory;
+import org.jeasy.rules.support.reader.JsonRuleDefinitionReader;
+import org.jeasy.rules.support.reader.YamlRuleDefinitionReader;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test
 public class TestRoutingGroupSelector {
+  public static final String TRINO_SOURCE_HEADER = "X-Trino-Source";
+
   public void testByRoutingGroupHeader() {
     HttpServletRequest mockRequest = mock(HttpServletRequest.class);
 
@@ -21,5 +30,25 @@ public class TestRoutingGroupSelector {
     // If the header is not present just return null.
     when(mockRequest.getHeader(ROUTING_GROUP_HEADER)).thenReturn(null);
     Assert.assertNull(RoutingGroupSelector.byRoutingGroupHeader().findRoutingGroup(mockRequest));
+  }
+
+  public void testByRoutingRulesEngine() {
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+
+    when(mockRequest.getHeader(TRINO_SOURCE_HEADER)).thenReturn("airflow");
+
+    Rule airflowRule = new RuleBuilder()
+        .name("airflow rule")
+        .description("if airflow route to etl cluster")
+        .when(facts -> ((HttpServletRequest) facts.get("request")).getHeader(
+              TRINO_SOURCE_HEADER).equals("airflow"))
+        .then(facts -> facts.put("routingGroup", "etl"))
+        .build();
+
+    Rules rules = new Rules(airflowRule);
+    Assert.assertEquals(
+        RoutingGroupSelector.byRoutingRulesEngine(rules).findRoutingGroup(mockRequest),
+        "etl");
+
   }
 }

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
@@ -51,4 +51,29 @@ public class TestRoutingGroupSelector {
         "etl");
 
   }
+
+  public void testByRoutingRulesEngine_FromFile() {
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    Rules rules = new Rules();
+
+    try {
+      MVELRuleFactory ruleFactory = new MVELRuleFactory(new YamlRuleDefinitionReader());
+      rules = ruleFactory.createRules(
+          new FileReader("src/test/resources/rules/routing_rules.yml"));
+    } catch (Exception e) {
+      System.out.println(e.getStackTrace());
+      System.out.println(e);
+    }
+
+    when(mockRequest.getHeader(TRINO_SOURCE_HEADER)).thenReturn("airflow");
+    Assert.assertEquals(
+        RoutingGroupSelector.byRoutingRulesEngine(rules).findRoutingGroup(mockRequest),
+        "etl");
+
+    when(mockRequest.getHeader(TRINO_SOURCE_HEADER)).thenReturn("airflow-coco");
+    Assert.assertEquals(
+        RoutingGroupSelector.byRoutingRulesEngine(rules).findRoutingGroup(mockRequest),
+        "etl-critical");
+
+  }
 }

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
@@ -115,7 +115,41 @@ public class TestRoutingGroupSelector {
         routingGroupSelector.findRoutingGroup(mockRequest), null);
   }
 
-  public void testByRoutingRulesEngineFileChange() {
-  }
+  public void testByRoutingRulesEngineFileChange() throws Exception {
+    File file = File.createTempFile("routing_rules", ".yml");
 
+    FileWriter fw = new FileWriter(file);
+    fw.write(
+        "---\n"
+        + "name: \"airflow\"\n"
+        + "description: \"if query from airflow, route to etl group\"\n"
+        + "condition: \"request.getHeader(\\\"X-Trino-Source\\\") == \\\"airflow\\\"\"\n"
+        + "actions:\n"
+        + "  - \"facts.put(\\\"routingGroup\\\", \\\"etl\\\")\"");
+    fw.close();
+
+    RoutingGroupSelector routingGroupSelector =
+        RoutingGroupSelector.byRoutingRulesEngine(file.getPath());
+
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+
+    when(mockRequest.getHeader(TRINO_SOURCE_HEADER)).thenReturn("airflow");
+    Assert.assertEquals(
+        routingGroupSelector.findRoutingGroup(mockRequest), "etl");
+
+    fw = new FileWriter(file);
+    fw.write(
+        "---\n"
+        + "name: \"airflow\"\n"
+        + "description: \"if query from airflow, route to etl group\"\n"
+        + "condition: \"request.getHeader(\\\"X-Trino-Source\\\") == \\\"airflow\\\"\"\n"
+        + "actions:\n"
+        + "  - \"facts.put(\\\"routingGroup\\\", \\\"etl2\\\")\"");
+    fw.close();
+
+    when(mockRequest.getHeader(TRINO_SOURCE_HEADER)).thenReturn("airflow");
+    Assert.assertEquals(
+        routingGroupSelector.findRoutingGroup(mockRequest), "etl2");
+    file.deleteOnExit();
+  }
 }

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestRoutingGroupSelector.java
@@ -68,10 +68,10 @@ public class TestRoutingGroupSelector {
 
     // query from airflow with label coco goes to etl-critical
     when(mockRequest.getHeader(TRINO_CLIENT_TAGS_HEADER)).thenReturn(
-        "email=person@example.com,label=coco");
+        "email=person@example.com,label=special");
     Assert.assertEquals(
         RoutingGroupSelector.byRoutingRulesEngine(rules).findRoutingGroup(mockRequest),
-        "etl-critical");
+        "etl-special");
 
     // query from mode goes to scheduled
     when(mockRequest.getHeader(TRINO_SOURCE_HEADER)).thenReturn("mode");

--- a/gateway-ha/src/test/resources/rules/routing_rules.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules.yml
@@ -10,9 +10,3 @@ description: "if query from airflow with special label, route to etl-special gro
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\").contains(\"label=special\")"
 actions:
   - "facts.put(\"routingGroup\", \"etl-special\")"
----
-name: "mode"
-description: "if query from mode, route to scheduled group"
-condition: "request.getHeader(\"X-Trino-Source\") == \"mode\""
-actions:
-  - "facts.put(\"routingGroup\", \"scheduled\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules.yml
@@ -7,6 +7,6 @@ actions:
 ---
 name: "airflow special"
 description: "if query from airflow with special label, route to etl-special group"
-condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\").contains(\"label=special\")"
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""
 actions:
   - "facts.put(\"routingGroup\", \"etl-special\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules.yml
@@ -7,9 +7,9 @@ actions:
 ---
 name: "airflow coco"
 description: "if query from airflow with label coco, route to etl-critical group"
-condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\").contains(\"label=coco\")"
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\").contains(\"label=special\")"
 actions:
-  - "facts.put(\"routingGroup\", \"etl-critical\")"
+  - "facts.put(\"routingGroup\", \"etl-special\")"
 ---
 name: "mode"
 description: "if query from mode, route to scheduled group"

--- a/gateway-ha/src/test/resources/rules/routing_rules.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules.yml
@@ -1,14 +1,18 @@
 ---
 name: "airflow"
-description: "default routing group for airflow queries is etl"
-priority: 1
+description: "if query from airflow, route to etl group"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
 actions:
   - "facts.put(\"routingGroup\", \"etl\")"
 ---
 name: "airflow coco"
-description: "airflow coco query goesto etl-critical"
-priority: 2
-condition: "request.getHeader(\"X-Trino-Source\") == \"airflow-coco\""
+description: "if query from airflow with label coco, route to etl-critical group"
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\").contains(\"label=coco\")"
 actions:
   - "facts.put(\"routingGroup\", \"etl-critical\")"
+---
+name: "mode"
+description: "if query from mode, route to scheduled group"
+condition: "request.getHeader(\"X-Trino-Source\") == \"mode\""
+actions:
+  - "facts.put(\"routingGroup\", \"scheduled\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules.yml
@@ -5,8 +5,8 @@ condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
 actions:
   - "facts.put(\"routingGroup\", \"etl\")"
 ---
-name: "airflow coco"
-description: "if query from airflow with label coco, route to etl-critical group"
+name: "airflow special"
+description: "if query from airflow with special label, route to etl-special group"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\").contains(\"label=special\")"
 actions:
   - "facts.put(\"routingGroup\", \"etl-special\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules.yml
@@ -1,0 +1,14 @@
+---
+name: "airflow"
+description: "default routing group for airflow queries is etl"
+priority: 1
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
+actions:
+  - "facts.put(\"routingGroup\", \"etl\")"
+---
+name: "airflow coco"
+description: "airflow coco query goesto etl-critical"
+priority: 2
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow-coco\""
+actions:
+  - "facts.put(\"routingGroup\", \"etl-critical\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules_atomic.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_atomic.yml
@@ -3,10 +3,10 @@ name: "airflow"
 description: "if query from airflow, route to etl group"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && (request.getHeader(\"X-Trino-Client-Tags\") == null || request.getHeader(\"X-Trino-Client-Tags\").isEmpty())"
 actions:
-  - "facts.put(\"routingGroup\", \"etl\")"
+  - "result.put(\"routingGroup\", \"etl\")"
 ---
 name: "airflow special"
 description: "if query from airflow with special label, route to etl-special group"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""
 actions:
-  - "facts.put(\"routingGroup\", \"etl-special\")"
+  - "result.put(\"routingGroup\", \"etl-special\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules_atomic.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_atomic.yml
@@ -1,0 +1,12 @@
+---
+name: "airflow"
+description: "if query from airflow, route to etl group"
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && (request.getHeader(\"X-Trino-Client-Tags\") == null || request.getHeader(\"X-Trino-Client-Tags\").isEmpty())"
+actions:
+  - "facts.put(\"routingGroup\", \"etl\")"
+---
+name: "airflow special"
+description: "if query from airflow with special label, route to etl-special group"
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""
+actions:
+  - "facts.put(\"routingGroup\", \"etl-special\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules_composite.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_composite.yml
@@ -5,7 +5,7 @@ composingRules:
   - name: "main condition"
     description: "source is airflow"
     priority: 0
-    condition: "request.?getHeader(\"X-Trino-Source\") == \"airflow\""
+    condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
     actions:
       - ""
   - name: "airflow subrules"

--- a/gateway-ha/src/test/resources/rules/routing_rules_composite.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_composite.yml
@@ -16,9 +16,9 @@ composingRules:
         priority: 0
         condition: "request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""
         actions:
-          - "facts.put(\"routingGroup\", \"etl-special\")"
+          - "result.put(\"routingGroup\", \"etl-special\")"
       - name: "airflow default"
         description: "airflow queries default to etl"
         condition: "true"
         actions:
-          - "facts.put(\"routingGroup\", \"etl\")"
+          - "result.put(\"routingGroup\", \"etl\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules_composite.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_composite.yml
@@ -1,0 +1,24 @@
+name: "airflow rule group"
+description: "routing rules for query from airflow"
+compositeRuleType: "ConditionalRuleGroup"
+composingRules:
+  - name: "main condition"
+    description: "source is airflow"
+    priority: 0
+    condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
+    actions:
+      - ""
+  - name: "airflow subrules"
+    compositeRuleType: "ActivationRuleGroup"
+    composingRules:
+      - name: "airflow special"
+        description: "special label"
+        priority: 0
+        condition: "request.getHeader(\"X-Trino-Client-Tags\").contains(\"label=special\")"
+        actions:
+          - "facts.put(\"routingGroup\", \"etl-special\")"
+      - name: "airflow default"
+        description: "airflow queries default to etl"
+        condition: "true"
+        actions:
+          - "facts.put(\"routingGroup\", \"etl\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules_composite.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_composite.yml
@@ -5,7 +5,7 @@ composingRules:
   - name: "main condition"
     description: "source is airflow"
     priority: 0
-    condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
+    condition: "request.?getHeader(\"X-Trino-Source\") == \"airflow\""
     actions:
       - ""
   - name: "airflow subrules"
@@ -14,7 +14,7 @@ composingRules:
       - name: "airflow special"
         description: "special label"
         priority: 0
-        condition: "request.getHeader(\"X-Trino-Client-Tags\").contains(\"label=special\")"
+        condition: "request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""
         actions:
           - "facts.put(\"routingGroup\", \"etl-special\")"
       - name: "airflow default"

--- a/gateway-ha/src/test/resources/rules/routing_rules_if_statements.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_if_statements.yml
@@ -4,8 +4,8 @@ description: "if query from airflow, route to etl group"
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
 actions:
   - "if (request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\") {
-      facts.put(\"routingGroup\", \"etl-special\")
+      result.put(\"routingGroup\", \"etl-special\")
     }
     else {
-      facts.put(\"routingGroup\", \"etl\")
+      result.put(\"routingGroup\", \"etl\")
     }"

--- a/gateway-ha/src/test/resources/rules/routing_rules_if_statements.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_if_statements.yml
@@ -1,0 +1,11 @@
+---
+name: "airflow"
+description: "if query from airflow, route to etl group"
+condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
+actions:
+  - "if (request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\") {
+      facts.put(\"routingGroup\", \"etl-special\")
+    }
+    else {
+      facts.put(\"routingGroup\", \"etl\")
+    }"

--- a/gateway-ha/src/test/resources/rules/routing_rules_priorities.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_priorities.yml
@@ -4,11 +4,11 @@ description: "if query from airflow, route to etl group"
 priority: 0
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
 actions:
-  - "facts.put(\"routingGroup\", \"etl\")"
+  - "result.put(\"routingGroup\", \"etl\")"
 ---
 name: "airflow special"
 description: "if query from airflow with special label, route to etl-special group"
 priority: 1
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""
 actions:
-  - "facts.put(\"routingGroup\", \"etl-special\")"
+  - "result.put(\"routingGroup\", \"etl-special\")"

--- a/gateway-ha/src/test/resources/rules/routing_rules_priorities.yml
+++ b/gateway-ha/src/test/resources/rules/routing_rules_priorities.yml
@@ -1,12 +1,14 @@
 ---
 name: "airflow"
 description: "if query from airflow, route to etl group"
+priority: 0
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\""
 actions:
   - "facts.put(\"routingGroup\", \"etl\")"
 ---
 name: "airflow special"
 description: "if query from airflow with special label, route to etl-special group"
+priority: 1
 condition: "request.getHeader(\"X-Trino-Source\") == \"airflow\" && request.getHeader(\"X-Trino-Client-Tags\") contains \"label=special\""
 actions:
   - "facts.put(\"routingGroup\", \"etl-special\")"

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.8.6</version>
+    <version>1.8.7</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.6</version>
+        <version>1.8.7</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
Currently, presto-gateway routes requests to backends by reading the `X-Trino-Routing-Group` header. 

This PR introduces a routing rules engine feature, allowing users to define custom logic to route queries. These rules are separated from application logic and kept in a config file, allowing for dynamic rule changes. These rules can use any method of a `HttpServletRequest` object, including get headers (https://trino.io/docs/current/develop/client-protocol.html)

