### PR TITLE
QueueBasedRouting: Use Running Count as fallback logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ mysql -uroot -proot123 -h127.0.0.1 -Dprestogateway
 Once logged in to mysql console, please run [gateway-ha-persistence.sql](/gateway-ha/src/main/resources/gateway-ha-persistence.sql) to populate the tables.
 
 ### Build and run
+
+Please note these steps have been verified with JDK 8 and 11. Higher versions of Java might run into unexpected issues. 
+
 run `mvn clean install` to build `presto-gateway`
 
 Edit the [config file](/gateway-ha/gateway-ha-config.yml) and update the mysql db information.
@@ -45,6 +48,9 @@ jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
 Remove `TLSv1, TLSv1.1` and redo the above steps to build and run `presto-gateway`.
 
 Now you can access load balanced presto at localhost:8080 port. We will refer to this as `prestogateway.lyft.com`
+
+If you see test failures while building `presto-gateway` or in an IDE, please  run `mvn process-classes` to instrument javalite models
+which are used by the tests . Ref [javalite-examples](https://github.com/javalite/javalite-examples/tree/master/simple-example#instrumentation) for more details.
 
 ## Gateway API
 

--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.8-SNAPSHOT</version>
+        <version>1.8.9-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.9-SNAPSHOT</version>
+        <version>1.8.9</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.8-SNAPSHOT</version>
+        <version>1.8.9-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.9-SNAPSHOT</version>
+        <version>1.8.9</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoQueueLengthChecker.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoQueueLengthChecker.java
@@ -20,6 +20,8 @@ public class PrestoQueueLengthChecker implements PrestoClusterStatsObserver {
   @Override
   public void observe(List<ClusterStats> stats) {
     Map<String, Map<String, Integer>> clusterQueueMap = new HashMap<String, Map<String, Integer>>();
+    Map<String, Map<String, Integer>> clusterRunningMap
+            = new HashMap<String, Map<String, Integer>>();
 
     for (ClusterStats stat : stats) {
       if (!clusterQueueMap.containsKey(stat.getRoutingGroup())) {
@@ -29,12 +31,20 @@ public class PrestoQueueLengthChecker implements PrestoClusterStatsObserver {
               }
             }
         );
+        clusterRunningMap.put(stat.getRoutingGroup(), new HashMap<String, Integer>() {
+              {
+                put(stat.getClusterId(), stat.getRunningQueryCount());
+              }
+            }
+        );
       } else {
         clusterQueueMap.get(stat.getRoutingGroup()).put(stat.getClusterId(),
             stat.getQueuedQueryCount());
+        clusterRunningMap.get(stat.getRoutingGroup()).put(stat.getClusterId(),
+                stat.getRunningQueryCount());
       }
     }
 
-    routingManager.updateRoutingTable(clusterQueueMap);
+    routingManager.updateRoutingTable(clusterQueueMap, clusterRunningMap);
   }
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
@@ -228,7 +228,8 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
         int minQueueLen = Collections.min(updatedQueueLengthMap.get(grp).values());
         if (minQueueLen == maxQueueLen) {
           log.info("Queue lengths equal: {} for all clusters in the group {}."
-                  + " Falling back to Running Counts", maxQueueLen, grp);
+                  + " Falling back to Running Counts : {}", maxQueueLen, grp,
+                  updatedRunningLengthMap.get(grp));
           queueMap.putAll(updatedRunningLengthMap.get(grp));
         } else {
           queueMap.putAll(updatedQueueLengthMap.get(grp));

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
@@ -226,7 +226,7 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
 
         int maxQueueLen = Collections.max(updatedQueueLengthMap.get(grp).values());
         int minQueueLen = Collections.min(updatedQueueLengthMap.get(grp).values());
-        if (minQueueLen == maxQueueLen) {
+        if (minQueueLen == maxQueueLen && updatedQueueLengthMap.get(grp).size() > 1) {
           log.info("Queue lengths equal: {} for all clusters in the group {}."
                   + " Falling back to Running Counts : {}", maxQueueLen, grp,
                   updatedRunningLengthMap.get(grp));

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
@@ -226,6 +226,7 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
 
         int maxQueueLen = Collections.max(updatedQueueLengthMap.get(grp).values());
         int minQueueLen = Collections.min(updatedQueueLengthMap.get(grp).values());
+
         if (minQueueLen == maxQueueLen && updatedQueueLengthMap.get(grp).size() > 1) {
           log.info("Queue lengths equal: {} for all clusters in the group {}."
                   + " Falling back to Running Counts : {}", maxQueueLen, grp,

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -26,6 +26,7 @@ public class TestPrestoQueueLengthRoutingTable {
   String[] mockRoutingGroups = {"adhoc", "scheduled"};
   String mockRoutingGroup = "adhoc";
   Map<String, Map<String, Integer>> clusterQueueMap;
+  Map<String, Map<String, Integer>> clusterRunningMap;
 
   @BeforeClass(alwaysRun = true)
   public void setUp() {
@@ -52,6 +53,7 @@ public class TestPrestoQueueLengthRoutingTable {
       backendManager.deactivateBackend(mockRoutingGroup + i);
     }
     clusterQueueMap = new HashMap<>();
+    clusterRunningMap = new HashMap<>();
   }
 
   private void addMockBackends(String groupName, int numBackends,
@@ -70,60 +72,49 @@ public class TestPrestoQueueLengthRoutingTable {
     }
   }
 
-  private void registerBackEndsWithRandomQueueLength(String groupName, int numBackends) {
-    int mockQueueLength = 0;
-    String backend;
-    int maxLength = 200;
-    Random generator = new Random();
-
-    Map<String, Integer> queueLenghts = new HashMap<>();
-
-    for (int i = 0; i < numBackends; i++) {
-      backend = groupName + i;
-      backendManager.activateBackend(backend);
-      queueLenghts.put(backend, generator.nextInt(maxLength));
-    }
-
-    clusterQueueMap.put(groupName, queueLenghts);
-    routingTable.updateRoutingTable(clusterQueueMap, clusterQueueMap);
-  }
-
   private void registerBackEndsWithRandomQueueLengths(String groupName, int numBackends) {
     int mockQueueLength = 0;
     String backend;
     Random rand = new Random();
-    Map<String, Integer> queueLenghts = new HashMap<>();
+    Map<String, Integer> queueLengths = new HashMap<>();
 
     for (int i = 0; i < numBackends; i++) {
       backend = groupName + i;
       backendManager.activateBackend(backend);
-      queueLenghts.put(backend, mockQueueLength += rand.nextInt(100));
+      queueLengths.put(backend, mockQueueLength += rand.nextInt(100));
     }
 
-    clusterQueueMap.put(groupName, queueLenghts);
-    routingTable.updateRoutingTable(clusterQueueMap, clusterQueueMap);
+    clusterQueueMap.put(groupName, queueLengths);
+    // Running counts don't matter if queue lengths are random.
+    routingTable.updateRoutingTable(clusterQueueMap, clusterRunningMap);
   }
 
   private void registerBackEnds(String groupName, int numBackends,
-                                int queueLengthDistributiveFactor) {
+                                int queueLengthDistributiveFactor,
+                                int runningLenDistributiveFactor) {
     int mockQueueLength = 0;
+    int mockRunningLength = 0;
     String backend;
 
-    Map<String, Integer> queueLenghts = new HashMap<>();
+    Map<String, Integer> queueLengths = new HashMap<>();
+    Map<String, Integer> runningLengths = new HashMap<>();
 
     for (int i = 0; i < numBackends; i++) {
       backend = groupName + i;
       backendManager.activateBackend(backend);
-      queueLenghts.put(backend, mockQueueLength += queueLengthDistributiveFactor);
+      queueLengths.put(backend, mockQueueLength += queueLengthDistributiveFactor);
+      runningLengths.put(backend, mockRunningLength += runningLenDistributiveFactor);
     }
 
-    clusterQueueMap.put(groupName, queueLenghts);
-    routingTable.updateRoutingTable(clusterQueueMap, clusterQueueMap);
+    clusterQueueMap.put(groupName, queueLengths);
+    clusterRunningMap.put(groupName, runningLengths);
+    routingTable.updateRoutingTable(clusterQueueMap, clusterRunningMap);
   }
 
-  private void resetBackends(String groupName, int numBk, int queueDistribution) {
+  private void resetBackends(String groupName, int numBk,
+                             int queueDistribution, int runningDistribution) {
     deactiveAllBackends();
-    registerBackEnds(groupName, numBk, queueDistribution);
+    registerBackEnds(groupName, numBk, queueDistribution, runningDistribution);
   }
 
   private Map<String, Integer> routeQueries(String groupName, int numRequests) {
@@ -149,11 +140,12 @@ public class TestPrestoQueueLengthRoutingTable {
   public void testRoutingWithEvenWeightDistribution() {
 
     int queueDistribution = 3;
+    int runningDistribution = 0;
 
     for (int numRequests : QUERY_VOLUMES) {
       for (int numBk = 1; numBk <= NUM_BACKENDS; numBk++) {
 
-        resetBackends(mockRoutingGroup, numBk, queueDistribution);
+        resetBackends(mockRoutingGroup, numBk, queueDistribution, runningDistribution);
         Map<String, Integer> routingDistribution = routeQueries(mockRoutingGroup, numRequests);
 
         // Useful for debugging
@@ -201,8 +193,6 @@ public class TestPrestoQueueLengthRoutingTable {
           assert routingDistribution.values().stream().mapToInt(Integer::intValue).sum()
               == numRequests;
         }
-
-
       }
     }
   }
@@ -210,11 +200,11 @@ public class TestPrestoQueueLengthRoutingTable {
   @Test
   public void testRoutingWithEqualWeightDistribution() {
     int queueDistribution = 0;
-
+    int runningDistribution = 0;
     for (int numRequests : QUERY_VOLUMES) {
       for (int numBk = 1; numBk <= NUM_BACKENDS; numBk++) {
 
-        resetBackends(mockRoutingGroup, numBk, queueDistribution);
+        resetBackends(mockRoutingGroup, numBk, queueDistribution, runningDistribution);
         Map<String, Integer> routingDistribution = routeQueries(mockRoutingGroup, numRequests);
 
         //Useful Debugging Info
@@ -235,6 +225,37 @@ public class TestPrestoQueueLengthRoutingTable {
     }
   }
 
+
+  @Test
+  public void testRoutingWithEqualQueueSkewedRunningDistribution() {
+    int queueDistribution = 0;
+    int runningDistribution = 100;
+
+    for (int numRequests : QUERY_VOLUMES) {
+      for (int numBk = 1; numBk <= NUM_BACKENDS; numBk++) {
+
+        resetBackends(mockRoutingGroup, numBk, queueDistribution, runningDistribution);
+        Map<String, Integer> routingDistribution = routeQueries(mockRoutingGroup, numRequests);
+
+        //Useful Debugging Info
+        /*
+        System.out.println("Input :" + clusterRunningMap.toString() + " Num of Requests:" +
+        numRequests
+        + " Internal Routing table: " + routingTable.getInternalWeightedRoutingTable
+        (mockRoutingGroup).toString()
+        + " Distribution: " + routingDistribution.toString());
+        */
+        if (numBk > 2 && routingDistribution.containsKey(mockRoutingGroup + (numBk - 1))) {
+          assert routingDistribution.get(mockRoutingGroup + (numBk - 1))
+                  <= Math.ceil(numRequests / numBk);
+        } else  {
+          assert routingDistribution.values().stream().mapToInt(Integer::intValue).sum()
+                  == numRequests;
+        }
+      }
+    }
+  }
+
   @Test
   public void testRoutingWithMultipleGroups() {
     int queueDistribution = 10;
@@ -242,7 +263,7 @@ public class TestPrestoQueueLengthRoutingTable {
     int numBk = 3;
 
     for (String grp : mockRoutingGroups) {
-      resetBackends(grp, numBk, queueDistribution);
+      resetBackends(grp, numBk, queueDistribution, 0);
       Map<String, Integer> routingDistribution = routeQueries(grp, numRequests);
 
       // Useful for debugging
@@ -298,7 +319,7 @@ public class TestPrestoQueueLengthRoutingTable {
       routingTable.updateRoutingTable(clusterQueueMap, clusterQueueMap);
     };
 
-    resetBackends(mockRoutingGroup, numBk, 0);
+    resetBackends(mockRoutingGroup, numBk, 0, 0);
     scheduler.scheduleAtFixedRate(activeClusterMonitor, 0, 1, SECONDS);
 
 

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -85,7 +85,7 @@ public class TestPrestoQueueLengthRoutingTable {
     }
 
     clusterQueueMap.put(groupName, queueLenghts);
-    routingTable.updateRoutingTable(clusterQueueMap);
+    routingTable.updateRoutingTable(clusterQueueMap, clusterQueueMap);
   }
 
   private void registerBackEndsWithRandomQueueLengths(String groupName, int numBackends) {
@@ -101,7 +101,7 @@ public class TestPrestoQueueLengthRoutingTable {
     }
 
     clusterQueueMap.put(groupName, queueLenghts);
-    routingTable.updateRoutingTable(clusterQueueMap);
+    routingTable.updateRoutingTable(clusterQueueMap, clusterQueueMap);
   }
 
   private void registerBackEnds(String groupName, int numBackends,
@@ -118,7 +118,7 @@ public class TestPrestoQueueLengthRoutingTable {
     }
 
     clusterQueueMap.put(groupName, queueLenghts);
-    routingTable.updateRoutingTable(clusterQueueMap);
+    routingTable.updateRoutingTable(clusterQueueMap, clusterQueueMap);
   }
 
   private void resetBackends(String groupName, int numBk, int queueDistribution) {
@@ -295,7 +295,7 @@ public class TestPrestoQueueLengthRoutingTable {
       }
       globalToggle.set(!globalToggle.get());
       clusterQueueMap.put(mockRoutingGroup, queueLenghts);
-      routingTable.updateRoutingTable(clusterQueueMap);
+      routingTable.updateRoutingTable(clusterQueueMap, clusterQueueMap);
     };
 
     resetBackends(mockRoutingGroup, numBk, 0);

--- a/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/test/java/com/lyft/data/gateway/ha/router/TestPrestoQueueLengthRoutingTable.java
@@ -329,7 +329,7 @@ public class TestPrestoQueueLengthRoutingTable {
         totalDistribution.putAll(routingDistribution);
       } else {
         for (String key : routingDistribution.keySet()) {
-          sum = totalDistribution.get(key) + routingDistribution.get(key);
+          sum = totalDistribution.getOrDefault(key, 0) + routingDistribution.get(key);
           totalDistribution.put(key, sum);
         }
       }

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.8.8-SNAPSHOT</version>
+    <version>1.8.9-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.8.9-SNAPSHOT</version>
-
+    <version>1.8.9</version>
+    
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
         <jetty.version>9.4.9.v20180320</jetty.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <lombok.version>1.18.10</lombok.version>
+        <lombok.version>1.18.22</lombok.version>
         <testng.version>6.10</testng.version>
         <mockwebserver.version>1.2.1</mockwebserver.version>
 

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.8-SNAPSHOT</version>
+        <version>1.8.9-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.9-SNAPSHOT</version>
+        <version>1.8.9</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
Changes: 
- Use running count as a fallback if queue count are the same. This doesn't change the core algo, just passes in running-counts if queuecounts are the same for a routing group.
- Some other minor changes/clean-up/version fixes to resolve some build errors.