### PR TITLE
Add Support for User Queue Level Routing

### DIFF
--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.10-SNAPSHOT</version>
+        <version>1.9.0</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.9</version>
+        <version>1.8.10-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.9</version>
+        <version>1.8.10-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.10-SNAPSHOT</version>
+        <version>1.9.0</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -5,6 +5,7 @@ import static com.lyft.data.gateway.ha.handler.QueryIdCachingProxyHandler.UI_API
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.lyft.data.gateway.ha.config.MonitorConfiguration;
 import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
@@ -139,8 +140,8 @@ public class ActiveClusterMonitor implements Managed {
     // Fetch Cluster level Stats.
     String target = backend.getProxyTo() + UI_API_STATS_PATH;
     String response = queryCluster(target);
-    if (response == null) {
-      log.error("Received null response for {}", target);
+    if (Strings.isNullOrEmpty(response)) {
+      log.error("Received null/empty response for {}", target);
       return  clusterStats;
     }
     clusterStats.setHealthy(true);
@@ -164,8 +165,8 @@ public class ActiveClusterMonitor implements Managed {
     Map<String, Integer> clusterUserStats = new HashMap<>();
     target = backend.getProxyTo() + UI_API_QUEUED_LIST_PATH;
     response = queryCluster(target);
-    if (response == null) {
-      log.error("Received null response for {}", target);
+    if (Strings.isNullOrEmpty(response)) {
+      log.error("Received null/empty response for {}", target);
       return clusterStats;
     }
     try {

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ClusterStats.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ClusterStats.java
@@ -1,5 +1,7 @@
 package com.lyft.data.gateway.ha.clustermonitor;
 
+import java.util.Map;
+
 import lombok.Data;
 import lombok.ToString;
 
@@ -15,4 +17,5 @@ public class ClusterStats {
   private String proxyTo;
   private String externalUrl;
   private String routingGroup;
+  private Map<String, Integer> userQueuedCount;
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
@@ -1,5 +1,6 @@
 package com.lyft.data.gateway.ha.router;
 
+import com.google.common.base.Strings;
 import com.lyft.data.gateway.ha.config.ProxyBackendConfiguration;
 import java.util.Collection;
 import java.util.Collections;
@@ -14,6 +15,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -35,6 +37,8 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
   private ConcurrentHashMap<String, Integer> routingGroupWeightSum;
   private ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>> clusterQueueLengthMap;
 
+  private ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>> userClusterQueueLengthMap;
+
   private Map<String, TreeMap<Integer, String>> weightedDistributionRouting;
 
   /**
@@ -47,6 +51,7 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
     routingGroupWeightSum = new ConcurrentHashMap<String, Integer>();
     clusterQueueLengthMap = new ConcurrentHashMap<String, ConcurrentHashMap<String, Integer>>();
     weightedDistributionRouting = new HashMap<String, TreeMap<Integer, String>>();
+    userClusterQueueLengthMap = new ConcurrentHashMap<>();
   }
 
   /**
@@ -182,7 +187,7 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
   /**
    * Update the Routing Table only if a previously known backend has been deactivated.
    * Newly added backends are handled through
-   * {@link PrestoQueueLengthRoutingTable#updateRoutingTable(Map, Map)}
+   * {@link PrestoQueueLengthRoutingTable#updateRoutingTable(Map, Map, Map)}
    * updateRoutingTable}
    */
   public void updateRoutingTable(String routingGroup, Set<String> backends) {
@@ -212,11 +217,23 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
    * Update routing Table with new Queue Lengths.
    */
   public void updateRoutingTable(Map<String, Map<String, Integer>> updatedQueueLengthMap,
-                                 Map<String, Map<String, Integer>> updatedRunningLengthMap) {
+                                 Map<String, Map<String, Integer>> updatedRunningLengthMap,
+                                 Map<String, Map<String, Integer>> updatedUserQueueLengthMap) {
     synchronized (lockObject) {
       log.debug("Update Routing table with new cluster queue lengths : [{}]",
               updatedQueueLengthMap.toString());
       clusterQueueLengthMap.clear();
+      userClusterQueueLengthMap.clear();
+
+      if (updatedUserQueueLengthMap != null) {
+        log.debug("Update user queue sizes:[{}]", updatedUserQueueLengthMap.toString());
+
+        for (String user : updatedUserQueueLengthMap.keySet()) {
+          ConcurrentHashMap<String, Integer> clusterQueueMap =
+                  new ConcurrentHashMap<>(updatedUserQueueLengthMap.get(user));
+          userClusterQueueLengthMap.put(user, clusterQueueMap);
+        }
+      }
 
       for (String grp : updatedQueueLengthMap.keySet()) {
         if (grp == null) {
@@ -270,7 +287,37 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
   /**
    * Looks up the closest weight to random number generated for a given routing group.
    */
-  public String getEligibleBackEnd(String routingGroup) {
+  public String getEligibleBackEnd(String routingGroup, String user) {
+
+    // Route to the least queued backend for the user out of all backends for that group
+    if (!Strings.isNullOrEmpty(user)) {
+      Map<String, Integer> clusterQueueCountForUser = userClusterQueueLengthMap.get(user);
+
+      if (clusterQueueCountForUser != null && !clusterQueueCountForUser.isEmpty()) {
+        Set<String> backends = clusterQueueLengthMap.get(routingGroup).keySet();
+        String leastQueuedCluster = null;
+        Integer minQueueCount = Integer.MAX_VALUE;
+        Integer maxQueueCount = Integer.MIN_VALUE;
+        for (String b : backends) {
+          // If missing, we assume no queued queries for the user on that cluster.
+          Integer queueCount = clusterQueueCountForUser.getOrDefault(b, 0);
+
+          if (queueCount < minQueueCount) {
+            leastQueuedCluster = b;
+            minQueueCount = queueCount;
+          }
+          if (queueCount > maxQueueCount) {
+            maxQueueCount = queueCount;
+          }
+        }
+        // If all clusters have the same queue count, then fallback to the older weighted logic.
+        if (!Strings.isNullOrEmpty(leastQueuedCluster) && minQueueCount != maxQueueCount) {
+          log.debug("Routing to:{} with userQueueCount:{}", leastQueuedCluster, minQueueCount);
+
+          return leastQueuedCluster;
+        }
+      }
+    }
     if (routingGroupWeightSum.containsKey(routingGroup)
         && weightedDistributionRouting.containsKey(routingGroup)) {
       int rnd = RANDOM.nextInt(routingGroupWeightSum.get(routingGroup));
@@ -285,12 +332,12 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
    * backend is found.
    */
   @Override
-  public String provideBackendForRoutingGroup(String routingGroup) {
+  public String provideBackendForRoutingGroup(String routingGroup, String user) {
     List<ProxyBackendConfiguration> backends =
         getGatewayBackendManager().getActiveBackends(routingGroup);
 
     if (backends.isEmpty()) {
-      return provideAdhocBackend();
+      return provideAdhocBackend(user);
     }
     Map<String, String> proxyMap = new HashMap<>();
     for (ProxyBackendConfiguration backend : backends) {
@@ -298,7 +345,7 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
     }
 
     updateRoutingTable(routingGroup, proxyMap.keySet());
-    String clusterId = getEligibleBackEnd(routingGroup);
+    String clusterId = getEligibleBackEnd(routingGroup, user);
     log.debug("Routing to eligible backend : [{}] for routing group: [{}]",
         clusterId, routingGroup);
 
@@ -318,7 +365,7 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
    * <p>d.
    */
   @Override
-  public String provideAdhocBackend() {
+  public String provideAdhocBackend(String user) {
     Map<String, String> proxyMap = new HashMap<>();
     List<ProxyBackendConfiguration> backends = getGatewayBackendManager().getActiveAdhocBackends();
     if (backends.size() == 0) {
@@ -331,7 +378,7 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
 
     updateRoutingTable("adhoc", proxyMap.keySet());
 
-    String clusterId = getEligibleBackEnd("adhoc");
+    String clusterId = getEligibleBackEnd("adhoc", user);
     log.debug("Routing to eligible backend : " + clusterId + " for routing group: adhoc");
     if (clusterId != null) {
       return proxyMap.get(clusterId);

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
@@ -226,8 +226,6 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
       userClusterQueueLengthMap.clear();
 
       if (updatedUserQueueLengthMap != null) {
-        log.debug("Update user queue sizes:[{}]", updatedUserQueueLengthMap.toString());
-
         for (String user : updatedUserQueueLengthMap.keySet()) {
           ConcurrentHashMap<String, Integer> clusterQueueMap =
                   new ConcurrentHashMap<>(updatedUserQueueLengthMap.get(user));
@@ -244,7 +242,8 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
         int maxQueueLen = Collections.max(updatedQueueLengthMap.get(grp).values());
         int minQueueLen = Collections.min(updatedQueueLengthMap.get(grp).values());
 
-        if (minQueueLen == maxQueueLen && updatedQueueLengthMap.get(grp).size() > 1) {
+        if (minQueueLen == maxQueueLen && updatedQueueLengthMap.get(grp).size() > 1
+                && updatedRunningLengthMap.containsKey(grp)) {
           log.info("Queue lengths equal: {} for all clusters in the group {}."
                   + " Falling back to Running Counts : {}", maxQueueLen, grp,
                   updatedRunningLengthMap.get(grp));
@@ -312,7 +311,7 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
         }
         // If all clusters have the same queue count, then fallback to the older weighted logic.
         if (!Strings.isNullOrEmpty(leastQueuedCluster) && minQueueCount != maxQueueCount) {
-          log.debug("Routing to:{} with userQueueCount:{}", leastQueuedCluster, minQueueCount);
+          log.debug("{} routing to:{}. userQueueCount:{}", user, leastQueuedCluster, minQueueCount);
 
           return leastQueuedCluster;
         }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/PrestoQueueLengthRoutingTable.java
@@ -285,7 +285,7 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
   }
 
   /**
-   * Looks up the closest weight to random number generated for a given routing group.
+   * Find the cluster with least user queue else fall back to overall cluster weight based routing.
    */
   public String getEligibleBackEnd(String routingGroup, String user) {
 
@@ -318,6 +318,7 @@ public class PrestoQueueLengthRoutingTable extends HaRoutingManager {
         }
       }
     }
+    // Looks up the closest weight to random number generated for a given routing group.
     if (routingGroupWeightSum.containsKey(routingGroup)
         && weightedDistributionRouting.containsKey(routingGroup)) {
       int rnd = RANDOM.nextInt(routingGroupWeightSum.get(routingGroup));

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingManager.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingManager.java
@@ -61,7 +61,7 @@ public abstract class RoutingManager {
    *
    * @return
    */
-  public String provideAdhocBackend() {
+  public String provideAdhocBackend(String user) {
     List<ProxyBackendConfiguration> backends = this.gatewayBackendManager.getActiveAdhocBackends();
     if (backends.size() == 0) {
       throw new IllegalStateException("Number of active backends found zero");
@@ -76,11 +76,11 @@ public abstract class RoutingManager {
    *
    * @return
    */
-  public String provideBackendForRoutingGroup(String routingGroup) {
+  public String provideBackendForRoutingGroup(String routingGroup, String user) {
     List<ProxyBackendConfiguration> backends =
         gatewayBackendManager.getActiveBackends(routingGroup);
     if (backends.isEmpty()) {
-      return provideAdhocBackend();
+      return provideAdhocBackend(user);
     }
     int backendId = Math.abs(RANDOM.nextInt()) % backends.size();
     return backends.get(backendId).getProxyTo();

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.8.9</version>
+    <version>1.8.10-SNAPSHOT</version>
     
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.8.10-SNAPSHOT</version>
-    
+    <version>1.9.0</version>
+
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.9</version>
+        <version>1.8.10-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.8.10-SNAPSHOT</version>
+        <version>1.9.0</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
Support Routing to cluster with the least queue for the User, fallback to existing Cluster Queue based Routing approach if user level queue size are equal/no-queue.

Makes use of "ui/api/query?state=QUEUED"  on the coordinator to fetch the current queued queries on the cluster. 

This is internal change to the routing manager but given this is a sizable change, I plan to bump up the version to `1.9.0` with this release

