### PR TITLE
Update Patch Dependencies Versions

### DIFF
--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.0</version>
+        <version>1.9.3</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -29,7 +29,7 @@
         <reflections.version>0.9.10</reflections.version>
         <ehcache.version>3.8.1</ehcache.version>
         <activejdbc.version>2.3</activejdbc.version>
-        <mysqlconnector.version>8.0.17</mysqlconnector.version>
+        <mysqlconnector.version>8.0.28</mysqlconnector.version>
         <environments>development</environments>
         <app.main.class>com.lyft.data.gateway.ha.HaGatewayLauncher</app.main.class>
     </properties>
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.17</version>
+            <version>8.0.28</version>
         </dependency>
         <!-- Test deps -->
         <dependency>

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -9,7 +9,6 @@
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
         <version>1.9.3</version>
-        <version>1.9.2</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.0</version>
+        <version>1.9.3</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.9.0</version>
+    <version>1.9.3</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <mockwebserver.version>1.2.1</mockwebserver.version>
 
         <maven.checkstyle.plugin.version>3.2.0</maven.checkstyle.plugin.version>
-        <puppycrawl.tools.checkstyle.version>9.3/puppycrawl.tools.checkstyle.version>
+        <puppycrawl.tools.checkstyle.version>9.3</puppycrawl.tools.checkstyle.version>
         <checkstyle.violation.ignore>NonEmptyAtclauseDescription,JavadocMethod
         </checkstyle.violation.ignore>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <mockwebserver.version>1.2.1</mockwebserver.version>
 
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
-        <puppycrawl.tools.checkstyle.version>8.8</puppycrawl.tools.checkstyle.version>
+        <puppycrawl.tools.checkstyle.version>7.7</puppycrawl.tools.checkstyle.version>
         <checkstyle.violation.ignore>NonEmptyAtclauseDescription,JavadocMethod
         </checkstyle.violation.ignore>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
         <testng.version>6.10</testng.version>
         <mockwebserver.version>1.2.1</mockwebserver.version>
 
-        <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
-        <puppycrawl.tools.checkstyle.version>7.7</puppycrawl.tools.checkstyle.version>
+        <maven.checkstyle.plugin.version>3.2.0</maven.checkstyle.plugin.version>
+        <puppycrawl.tools.checkstyle.version>9.3/puppycrawl.tools.checkstyle.version>
         <checkstyle.violation.ignore>NonEmptyAtclauseDescription,JavadocMethod
         </checkstyle.violation.ignore>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jetty.version>9.4.9.v20180320</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <slf4j.version>1.7.25</slf4j.version>
         <lombok.version>1.18.22</lombok.version>
         <testng.version>6.10</testng.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
         <testng.version>6.10</testng.version>
         <mockwebserver.version>1.2.1</mockwebserver.version>
 
-        <maven.checkstyle.plugin.version>3.2.0</maven.checkstyle.plugin.version>
-        <puppycrawl.tools.checkstyle.version>9.3</puppycrawl.tools.checkstyle.version>
+        <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
+        <puppycrawl.tools.checkstyle.version>8.8</puppycrawl.tools.checkstyle.version>
         <checkstyle.violation.ignore>NonEmptyAtclauseDescription,JavadocMethod
         </checkstyle.violation.ignore>
     </properties>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.1</version>
+            <version>4.5.13</version>
         </dependency>
 
         <!-- Test deps -->

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.0</version>
+        <version>1.9.3</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
Bumping patch versions for dependencies. This should be backward compatible/safe : 

- Jetty Patch version update to latest 9.4.x released 6/22 : https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.48.v20220622 . 
- Bump mysql-connector-java from 8.0.17 to 8.0.28
- Bump httpclient from 4.5.1 to 4.5.13 
-