### PR TITLE
Update thread pool for ClusterMonitor

### DIFF
--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.0</version>
+        <version>1.9.1</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.0</version>
+        <version>1.9.1</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -33,7 +33,7 @@ public class ActiveClusterMonitor implements Managed {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   public static final int BACKEND_CONNECT_TIMEOUT_SECONDS = 15;
   public static final int MONITOR_TASK_DELAY_MIN = 1;
-  public static final int DEFAULT_THREAD_POOL_SIZE = 10;
+  public static final int DEFAULT_THREAD_POOL_SIZE = 20;
 
   private static final String SESSION_USER = "sessionUser";
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.9.0</version>
+    <version>1.9.1</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.0</version>
+        <version>1.9.1</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
Increase the default thread-pool size to accommodate latency-sensitive observers for large number of trino clusters. 