### PR TITLE
Filter out unhealthy clusters from queue based routing

### DIFF
--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.1</version>
+        <version>1.9.2</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.1</version>
+        <version>1.9.2</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoQueueLengthChecker.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoQueueLengthChecker.java
@@ -53,8 +53,8 @@ public class PrestoQueueLengthChecker implements PrestoClusterStatsObserver {
       // Create inverse map from user -> {cluster-> count}
       if (stat.getUserQueuedCount() != null && !stat.getUserQueuedCount().isEmpty()) {
         for (Map.Entry<String, Integer> queueCount : stat.getUserQueuedCount().entrySet()) {
-          Map<String, Integer> clusterQueue = userClusterQueuedCount.getOrDefault(queueCount.getKey(),
-                  new HashMap<>());
+          Map<String, Integer> clusterQueue = userClusterQueuedCount.getOrDefault(
+                  queueCount.getKey(), new HashMap<>());
           clusterQueue.put(stat.getClusterId(), queueCount.getValue());
           userClusterQueuedCount.put(queueCount.getKey(), clusterQueue);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.9.1</version>
+    <version>1.9.2</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.1</version>
+        <version>1.9.2</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
We generate `healthy` flag as part of ClusterMonitor but don't use it for routing i.e. still route queries to that cluster. 

This filters out unhealthy clusters from queue based routing logic + adds some npe checks. 