### PR TITLE
Bump Patch Versions

### DIFF
--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.3</version>
+        <version>1.9.4</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -19,7 +19,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>1.3.2</dropwizard.version>
+        <dropwizard.version>1.3.29</dropwizard.version>
         <guice.version>4.1.0</guice.version>
         <reflections.version>0.9.10</reflections.version>
     </properties>

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -21,7 +21,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jetty.version>9.4.9.v20180320</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <dropwizard.version>1.3.8</dropwizard.version>
         <guice.version>4.1.0</guice.version>
         <guava.version>23.0</guava.version>

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jetty.version>9.4.48.v20220622</jetty.version>
-        <dropwizard.version>1.3.8</dropwizard.version>
+        <dropwizard.version>1.3.29</dropwizard.version>
         <guice.version>4.1.0</guice.version>
         <guava.version>23.0</guava.version>
         <jeasy.version>4.1.0</jeasy.version>

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.3</version>
+        <version>1.9.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.9.3</version>
+    <version>1.9.4</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.3</version>
+        <version>1.9.4</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
Follow-up to https://github.com/lyft/presto-gateway/pull/179 . A couple of other patch versions updates.

Jetty Patch version update to latest 9.4.x released 6/22 : https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.48.v20220622 in gateway-ha

Dropwizard patch version to  1.3.29  to pull in https://github.com/dropwizard/dropwizard/pull/3527 
