### PR TITLE
mysql-connector to 8.0.17

### DIFF
--- a/baseapp/pom.xml
+++ b/baseapp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.4</version>
+        <version>1.9.5</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.4</version>
+        <version>1.9.5</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/gateway-ha/pom.xml
+++ b/gateway-ha/pom.xml
@@ -29,7 +29,7 @@
         <reflections.version>0.9.10</reflections.version>
         <ehcache.version>3.8.1</ehcache.version>
         <activejdbc.version>2.3</activejdbc.version>
-        <mysqlconnector.version>8.0.28</mysqlconnector.version>
+        <mysqlconnector.version>8.0.17</mysqlconnector.version>
         <environments>development</environments>
         <app.main.class>com.lyft.data.gateway.ha.HaGatewayLauncher</app.main.class>
     </properties>
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>8.0.17</version>
         </dependency>
         <!-- Test deps -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>prestogateway-parent</artifactId>
     <name>prestogateway-parent</name>
     <packaging>pom</packaging>
-    <version>1.9.4</version>
+    <version>1.9.5</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lyft.data</groupId>
         <artifactId>prestogateway-parent</artifactId>
-        <version>1.9.4</version>
+        <version>1.9.5</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
mysql-connector upgrade seems to be creating issues with non-ascii chars in query-text. For now, reverting only this back to 8.0.17. 