### PR TITLE
Support proxying /oauth2 to enable OAuth authentication

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/handler/QueryIdCachingProxyHandler.java
@@ -37,6 +37,7 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
   public static final String UI_API_STATS_PATH = "/ui/api/stats";
   public static final String UI_API_QUEUED_LIST_PATH = "/ui/api/query?state=QUEUED";
   public static final String PRESTO_UI_PATH = "/ui";
+  public static final String OAUTH2_PATH = "/oauth2";
   public static final String USER_HEADER = "X-Trino-User";
   public static final String ALTERNATE_USER_HEADER = "X-Presto-User";
   public static final String SOURCE_HEADER = "X-Trino-Source";
@@ -96,6 +97,7 @@ public class QueryIdCachingProxyHandler extends ProxyHandler {
     return path.startsWith(V1_STATEMENT_PATH)
         || path.startsWith(V1_QUERY_PATH)
         || path.startsWith(PRESTO_UI_PATH)
+        || path.startsWith(OAUTH2_PATH)
         || path.startsWith(V1_INFO_PATH)
         || path.startsWith(UI_API_STATS_PATH);
   }


### PR DESCRIPTION
Hi folks,

Thank you for open-sourcing the presto-gateway, it's a very nifty piece of software!

We're currently using it with Trino backends and [OAuth2 authentication](https://trino.io/docs/current/security/oauth2.html), which works very well on its own but breaks when clusters are put behind the presto-gateway, as OAuth2 does an HTTP callback to Trino under `/oauth2`. This returns a 404 as the presto-gateway doesn't know about this path and treats is as an error.

This small PR whitelists paths starting with `/oauth2` and instructs presto-gateway to reverse-proxy it to a backend, enabling authenticating via OAuth2.

Let me know if there's anything else I can do to make this PR more likely to land, as we're happy using upstream rather than a fork. :)

Thank you!