### PR TITLE
Fix assets path to fix admin entity editing

### DIFF
--- a/gateway-ha/src/main/resources/template/entity-view.ftl
+++ b/gateway-ha/src/main/resources/template/entity-view.ftl
@@ -1,14 +1,14 @@
 <html>
 <head>
     <meta charset="UTF-8"/>
-    <link rel="stylesheet" type="text/css" href="assets/css/common.css"/>
-    <link rel="stylesheet" type="text/css" href="assets/css/jquery.dataTables.min.css"/>
-    <script src="assets/js/jquery-3.3.1.js"></script>
+    <link rel="stylesheet" type="text/css" href="/assets/css/common.css"/>
+    <link rel="stylesheet" type="text/css" href="/assets/css/jquery.dataTables.min.css"/>
+    <script src="/assets/js/jquery-3.3.1.js"></script>
 
     <!-- JSON Editor comes here-->
-    <link rel="stylesheet" href="assets/js/jsonedit/jsoneditor.min.css"/>
-    <script src="assets/js/jsonedit/jsoneditor.min.js" defer></script>
-    <script src="assets/js/entity-editor.js" defer></script>
+    <link rel="stylesheet" href="/assets/js/jsonedit/jsoneditor.min.css"/>
+    <script src="/assets/js/jsonedit/jsoneditor.min.js" defer></script>
+    <script src="/assets/js/entity-editor.js" defer></script>
 
     <script type="text/javascript">
         $(document).ready(function () {


### PR DESCRIPTION
Hey folks,

I was trying to get entity editing to work as per the README under [Gateway Admin UI](https://github.com/lyft/presto-gateway#gateway-admin-ui---add-and-modify-backend-information)), but the page at `https://<presto-gateway>/entity/` ended up broken. I realised that CSS / JS resources weren't loading because the template references assets via relative path, and the admin page is located at `/entity`. The relative path therefore ends up being `/entity/assets/...` which receives a 404.

The attached PR fixes this by setting an absolute path for `/assets`, rather than relative.

(Note: I _assume_ that this is the correct thing to do, but I'm not 100% sure as the docs don't actually specify the URL for the admin page - maybe I'm just using the wrong path? Please let me know if that's the case :) )