### PR TITLE
Fix href property on the query history UI

### DIFF
--- a/gateway-ha/src/main/resources/template/query-history-view.ftl
+++ b/gateway-ha/src/main/resources/template/query-history-view.ftl
@@ -60,7 +60,7 @@
             <tbody>
             <#list queryHistory as q>
                 <tr>
-                    <td><a href="/ui/query.html?${q.queryId}"
+                    <td><a href="${q.backendUrl}/ui/query.html?${q.queryId}"
                            target="_blank">${q.queryId}</a></td>
                     <td>  ${q.user}</td>
                     <td>


### PR DESCRIPTION
Related to
- https://github.com/lyft/presto-gateway/issues/162
- https://github.com/lyft/presto-gateway/pull/193

Description
- I think it is more simple fix for this issue, because `QueryDetail` object already has `backendUrl` field.

```
@Data
  @ToString
  class QueryDetail implements Comparable<QueryDetail> {
    private String queryId;
    private String queryText;
    private String user;
    private String source;
    private String backendUrl;
    private long captureTime;

    @Override
    public int compareTo(QueryDetail o) {
      if (this.captureTime < o.captureTime) {
        return 1;
      } else {
        return this.captureTime == o.captureTime ? 0 : -1;
      }
    }
  }
```