### PR TITLE
Activate queue based router as default & Consider backend with no worker as unhealthy

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/ActiveClusterMonitor.java
@@ -150,6 +150,9 @@ public class ActiveClusterMonitor implements Managed {
       result = OBJECT_MAPPER.readValue(response, HashMap.class);
 
       clusterStats.setNumWorkerNodes((int) result.get("activeWorkers"));
+      if (clusterStats.getNumWorkerNodes() < 1) {
+        clusterStats.setHealthy(false);
+      }
       clusterStats.setQueuedQueryCount((int) result.get("queuedQueries"));
       clusterStats.setRunningQueryCount((int) result.get("runningQueries"));
       clusterStats.setBlockedQueryCount((int) result.get("blockedQueries"));

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoQueueLengthChecker.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/clustermonitor/PrestoQueueLengthChecker.java
@@ -4,11 +4,13 @@ import com.lyft.data.gateway.ha.router.PrestoQueueLengthRoutingTable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Updates the QueueLength Based Routing Manager {@link PrestoQueueLengthRoutingTable} with
  * updated queue lengths of active clusters.
  */
+@Slf4j
 public class PrestoQueueLengthChecker implements PrestoClusterStatsObserver {
 
   PrestoQueueLengthRoutingTable routingManager;
@@ -27,6 +29,7 @@ public class PrestoQueueLengthChecker implements PrestoClusterStatsObserver {
 
     for (ClusterStats stat : stats) {
       if (!stat.isHealthy()) {
+        log.warn("UNHEALTHY CLUSTER: {}", stat.getClusterId());
         // Skip if the cluster isn't healthy
         continue;
       }
@@ -60,7 +63,9 @@ public class PrestoQueueLengthChecker implements PrestoClusterStatsObserver {
         }
       }
     }
-
+    log.info("CLUSTER QUEUE MAP: {}", clusterQueueMap);
+    log.info("CLUSTER RUNNING MAP: {}", clusterRunningMap);
+    log.debug("USER CLUSTER QUEUE COUNT MAP: {}", userClusterQueuedCount);
     routingManager.updateRoutingTable(clusterQueueMap, clusterRunningMap, userClusterQueuedCount);
   }
 }

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/ClusterStateListenerModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/ClusterStateListenerModule.java
@@ -1,14 +1,18 @@
 package com.lyft.data.gateway.ha.module;
 
+import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.lyft.data.baseapp.AppModule;
 import com.lyft.data.gateway.ha.clustermonitor.HealthChecker;
 import com.lyft.data.gateway.ha.clustermonitor.PrestoClusterStatsObserver;
+import com.lyft.data.gateway.ha.clustermonitor.PrestoQueueLengthChecker;
 import com.lyft.data.gateway.ha.config.HaGatewayConfiguration;
 import com.lyft.data.gateway.ha.config.MonitorConfiguration;
 import com.lyft.data.gateway.ha.config.NotifierConfiguration;
 import com.lyft.data.gateway.ha.notifier.EmailNotifier;
+import com.lyft.data.gateway.ha.router.PrestoQueueLengthRoutingTable;
+import com.lyft.data.gateway.ha.router.RoutingManager;
 import io.dropwizard.setup.Environment;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +20,7 @@ import java.util.List;
 public class ClusterStateListenerModule extends AppModule<HaGatewayConfiguration, Environment> {
   List<PrestoClusterStatsObserver> observers;
   MonitorConfiguration monitorConfig;
+  @Inject private RoutingManager routingManager;
 
   public ClusterStateListenerModule(HaGatewayConfiguration config, Environment env) {
     super(config, env);
@@ -34,6 +39,8 @@ public class ClusterStateListenerModule extends AppModule<HaGatewayConfiguration
     observers = new ArrayList<>();
     NotifierConfiguration notifierConfiguration = getConfiguration().getNotifier();
     observers.add(new HealthChecker(new EmailNotifier(notifierConfiguration)));
+    observers.add(
+        new PrestoQueueLengthChecker((PrestoQueueLengthRoutingTable) routingManager));
     return observers;
   }
 

--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/module/HaGatewayProviderModule.java
@@ -13,7 +13,7 @@ import com.lyft.data.gateway.ha.router.GatewayBackendManager;
 import com.lyft.data.gateway.ha.router.HaGatewayManager;
 import com.lyft.data.gateway.ha.router.HaQueryHistoryManager;
 import com.lyft.data.gateway.ha.router.HaResourceGroupsManager;
-import com.lyft.data.gateway.ha.router.HaRoutingManager;
+import com.lyft.data.gateway.ha.router.PrestoQueueLengthRoutingTable;
 import com.lyft.data.gateway.ha.router.QueryHistoryManager;
 import com.lyft.data.gateway.ha.router.ResourceGroupsManager;
 import com.lyft.data.gateway.ha.router.RoutingGroupSelector;
@@ -37,8 +37,9 @@ public class HaGatewayProviderModule extends AppModule<HaGatewayConfiguration, E
     resourceGroupsManager = new HaResourceGroupsManager(connectionManager);
     gatewayBackendManager = new HaGatewayManager(connectionManager);
     queryHistoryManager = new HaQueryHistoryManager(connectionManager);
-    routingManager =
-        new HaRoutingManager(gatewayBackendManager, (HaQueryHistoryManager) queryHistoryManager);
+    routingManager = new PrestoQueueLengthRoutingTable(
+        gatewayBackendManager,
+        (HaQueryHistoryManager) queryHistoryManager);
   }
 
   protected ProxyHandler getProxyHandler() {


### PR DESCRIPTION
There were valuable updates on routing logic with `PrestoQueueLengthRoutingTable` routing manager and `PrestoQueueLengthChecker` observer, like below.
- https://github.com/lyft/presto-gateway/pull/173
- https://github.com/lyft/presto-gateway/pull/176
- https://github.com/lyft/presto-gateway/pull/183

But, current codebase in this repository don't use both `PrestoQueueLengthRoutingTable` and `PrestoQueueLengthChecker`. And besides, there is no option to activate those useful feature without code modification.

I think, there is no reason to maintain `HaRoutingManager` as default, because `PrestoQueueLengthRoutingTable` is derived from it. So, it make sense to activate `PrestoQueueLengthRoutingTable` and `PrestoQueueLengthChecker` by default.

Plus, I add minor logic to consider cluster with no worker as unhealthy.