### PR TITLE
Share routing rules among all requests

### DIFF
--- a/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
+++ b/gateway-ha/src/main/java/com/lyft/data/gateway/ha/router/RoutingGroupSelector.java
@@ -36,24 +36,21 @@ public interface RoutingGroupSelector {
   static RoutingGroupSelector byRoutingRulesEngine(String rulesConfigPath) {
     RulesEngine rulesEngine = new DefaultRulesEngine();
     MVELRuleFactory ruleFactory = new MVELRuleFactory(new YamlRuleDefinitionReader());
-
-    return request -> {
-      try {
-        Rules rules = ruleFactory.createRules(
-            new FileReader(rulesConfigPath));
+    try {
+      final Rules rules = ruleFactory.createRules(new FileReader(rulesConfigPath));
+      return request -> {
         Facts facts = new Facts();
         HashMap<String, String> result = new HashMap<String, String>();
         facts.put("request", request);
         facts.put("result", result);
         rulesEngine.fire(rules, facts);
         return result.get("routingGroup");
-      } catch (Exception e) {
-        Logger.log.error("Error opening rules configuration file,"
-            + " using routing group header as default.", e);
-        return Optional.ofNullable(request.getHeader(ROUTING_GROUP_HEADER))
-          .orElse(request.getHeader(ALTERNATE_ROUTING_GROUP_HEADER));
-      }
-    };
+      };
+    } catch (Exception e) {
+      Logger.log.error("Error opening rules configuration file,"
+          + " using routing group header as default.", e);
+      return byRoutingGroupHeader();
+    }
   }
 
   /**


### PR DESCRIPTION
Small performance improvement plus it very likely closes #166 (it solved it for us at least).

By placing the `Rules` creation inside the lambda, the previous implementation required to read the routing rules config file for each request, adding unnecessary latency. More importantly, it was not thread-safe, as the `rulesEngine` and `ruleFactory` were shared among all requests, only the `Rules` creation wasn't.

The `ruleFactory` is of class `MVELRuleFactory`, which is stateful - it has `RuleDefinitionReader reader` and `ParserContext parserContext` as private members. Creating the `Rules` changes that state, so it should not be shared between concurrent threads. `Rules` OTOH is a read-only class after it's created (it's just iterated over by the `DefaultRulesEngine`). Given that the rules are the same for all requests, and that the `Rules` usage is thread-safe, it makes sense to share it across all of them.

We have deployed this code in production at Datadog and our APM profiling tool shows a reduction of around ~1-2%, plus we stopped seeing the error described in https://github.com/lyft/presto-gateway/issues/166 . 