### PR TITLE
Point to official Trino Gateway repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# presto-gateway
+### NOTE: This is a legacy version of Trino Gateway. Please refer to https://github.com/trinodb/trino-gateway for active development and updates moving forward.
+
+
+# presto-gateway (outdated)
 
 A load balancer / proxy / gateway for presto compute engine.
 


### PR DESCRIPTION
Updating README to reflect the following: presto-gateway has been absorbed by trino-gateway, which is in active development and officially adopted by trinodb: https://github.com/trinodb/trino-gateway